### PR TITLE
fix: Change websocket lib for Blazor WASM to use realtime

### DIFF
--- a/Realtime/Channel.cs
+++ b/Realtime/Channel.cs
@@ -1,392 +1,391 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Timers;
 using Newtonsoft.Json;
 using Supabase.Realtime.Attributes;
-using WebSocketSharp;
 using static Supabase.Realtime.Channel;
 
 [assembly: InternalsVisibleTo("RealtimeTests")]
 namespace Supabase.Realtime
 {
+  /// <summary>
+  /// Class representation of a channel subscription
+  /// </summary>
+  public class Channel
+  {
     /// <summary>
-    /// Class representation of a channel subscription
+    /// Channel state with associated string representations.
     /// </summary>
-    public class Channel
+    public enum ChannelState
     {
-        /// <summary>
-        /// Channel state with associated string representations.
-        /// </summary>
-        public enum ChannelState
-        {
-            [MapTo("closed")]
-            Closed,
-            [MapTo("errored")]
-            Errored,
-            [MapTo("joined")]
-            Joined,
-            [MapTo("joining")]
-            Joining,
-            [MapTo("leaving")]
-            Leaving
-        }
-
-        /// <summary>
-        /// Invoked when the `INSERT` event is raised.
-        /// </summary>
-        public event EventHandler<SocketResponseEventArgs> OnInsert;
-
-        /// <summary>
-        /// Invoked when the `UPDATE` event is raised.
-        /// </summary>
-        public event EventHandler<SocketResponseEventArgs> OnUpdate;
-
-        /// <summary>
-        /// Invoked when the `DELETE` event is raised.
-        /// </summary>
-        public event EventHandler<SocketResponseEventArgs> OnDelete;
-
-        /// <summary>
-        /// Invoked anytime a message is decoded within this topic.
-        /// </summary>
-        public event EventHandler<SocketResponseEventArgs> OnMessage;
-
-        /// <summary>
-        /// Invoked when this channel listener is closed
-        /// </summary>
-        public event EventHandler<ChannelStateChangedEventArgs> StateChanged;
-
-        /// <summary>
-        /// Invoked when the socket drops or crashes.
-        /// </summary>
-        public event EventHandler<ChannelStateChangedEventArgs> OnError;
-
-        /// <summary>
-        /// Invoked when the channel is explicitly closed by the client.
-        /// </summary>
-        public event EventHandler<ChannelStateChangedEventArgs> OnClose;
-
-        public bool IsClosed => State == ChannelState.Closed;
-        public bool IsErrored => State == ChannelState.Errored;
-        public bool IsJoined => State == ChannelState.Joined;
-        public bool IsJoining => State == ChannelState.Joining;
-        public bool IsLeaving => State == ChannelState.Leaving;
-
-        /// <summary>
-        /// Shorthand accessor for the Client's socket connection.
-        /// </summary>
-        public Socket Socket { get => Client.Instance.Socket; }
-
-        /// <summary>
-        /// The Channel's current state.
-        /// </summary>
-        public ChannelState State { get; private set; } = ChannelState.Closed;
-
-        /// <summary>
-        /// Channel Parameters, passed on the Join Push.
-        /// </summary>
-        public Dictionary<string, string> Parameters = new Dictionary<string, string>();
-
-        /// <summary>
-        /// The Channel's (unique) topic indentifier.
-        /// </summary>
-        public string Topic { get => Utils.GenerateChannelTopic(database, schema, table, col, value); }
-
-        /// <summary>
-        /// Flag stating whether a channel has been joined once or not.
-        /// </summary>
-        public bool HasJoinedOnce { get; private set; }
-
-        private string database;
-        private string schema;
-        private string table;
-        private string col;
-        private string value;
-
-        /// <summary>
-        /// The initial request to join a channel (repeated on channel disconnect)
-        /// </summary>
-        internal Push JoinPush;
-        internal Push LastPush;
-
-        /// <summary>
-        /// Buffer of Pushes held because of Socket availablity
-        /// </summary>
-        internal List<Push> buffer = new List<Push>();
-
-        private bool canPush => IsJoined && Socket.IsConnected;
-        private bool hasJoinedOnce = false;
-        private Timer rejoinTimer;
-        private bool isRejoining = false;
-
-        /// <summary>
-        /// Initializes a Channel - must call `Subscribe()` to receive events.
-        /// </summary>
-        /// <param name="database"></param>
-        /// <param name="schema"></param>
-        /// <param name="table"></param>
-        /// <param name="col"></param>
-        /// <param name="value"></param>
-        public Channel(string database, string schema, string table, string col, string value, Dictionary<string, string> parameters = null)
-        {
-            if (parameters == null)
-            {
-                parameters = new Dictionary<string, string>();
-            }
-
-            Parameters = parameters;
-
-            this.database = database;
-            this.schema = schema;
-            this.table = table;
-
-            this.col = col;
-            this.value = value;
-
-            JoinPush = new Push(this, Constants.CHANNEL_EVENT_JOIN, Parameters);
-
-            rejoinTimer = new Timer(Client.Instance.Options.Timeout.TotalMilliseconds);
-            rejoinTimer.Elapsed += HandleRejoinTimerElapsed;
-            rejoinTimer.AutoReset = true;
-        }
-
-        /// <summary>
-        /// Subscribes to the channel given supplied options/params.
-        /// </summary>
-        /// <param name="timeoutMs"></param>
-        public Task<Channel> Subscribe(int timeoutMs = Constants.DEFAULT_TIMEOUT)
-        {
-            var tsc = new TaskCompletionSource<Channel>();
-
-            if (hasJoinedOnce)
-            {
-                tsc.SetException(new Exception("`Subscribe` can only be called a single time per channel instance."));
-                return tsc.Task;
-            }
-
-            EventHandler<ChannelStateChangedEventArgs> channelCallback = null;
-            EventHandler joinPushTimeoutCallback = null;
-
-            channelCallback = (object sender, ChannelStateChangedEventArgs e) =>
-            {
-                switch (e.State)
-                {
-                    // Success!
-                    case ChannelState.Joined:
-                        HasJoinedOnce = true;
-                        StateChanged -= channelCallback;
-                        JoinPush.OnTimeout -= joinPushTimeoutCallback;
-
-                        // Clear buffer
-                        foreach (var item in buffer)
-                            item.Send();
-                        buffer.Clear();
-
-                        tsc.TrySetResult(this);
-                        break;
-                    // Failure
-                    case ChannelState.Closed:
-                    case ChannelState.Errored:
-                        StateChanged -= channelCallback;
-                        JoinPush.OnTimeout -= joinPushTimeoutCallback;
-
-                        tsc.TrySetException(new Exception("Error occurred connecting to channel. Check logs."));
-                        break;
-                }
-            };
-
-            // Throw an exception if there is a problem receiving a join response
-            joinPushTimeoutCallback = (object sender, EventArgs e) =>
-            {
-                StateChanged -= channelCallback;
-                JoinPush.OnTimeout -= joinPushTimeoutCallback;
-
-                tsc.TrySetException(new PushTimeoutException());
-            };
-
-            StateChanged += channelCallback;
-
-            // Set a flag to prevent multiple join attempts.
-            hasJoinedOnce = true;
-
-            // Init and send join.
-            Rejoin(timeoutMs);
-            JoinPush.OnTimeout += joinPushTimeoutCallback;
-
-            return tsc.Task;
-        }
-
-        /// <summary>
-        /// Unsubscribes from the channel.
-        /// </summary>
-        public void Unsubscribe()
-        {
-            SetState(ChannelState.Leaving);
-
-            var leavePush = new Push(this, Constants.CHANNEL_EVENT_LEAVE, null);
-            leavePush.Send();
-
-            TriggerChannelStateEvent(new ChannelStateChangedEventArgs(ChannelState.Closed));
-        }
-
-        /// <summary>
-        /// Sends a `Push` request under this channel.
-        ///
-        /// Maintains a buffer in the event push is called prior to the channel being joined.
-        /// </summary>
-        /// <param name="eventName"></param>
-        /// <param name="payload"></param>
-        /// <param name="timeoutMs"></param>
-        public void Push(string eventName, object payload, int timeoutMs = Constants.DEFAULT_TIMEOUT)
-        {
-            if (!hasJoinedOnce)
-                throw new Exception($"Tried to push '{eventName}' to '{Topic}' before joining. Use `Channel.Subscribe()` before pushing events");
-
-            LastPush = new Push(this, eventName, payload, timeoutMs);
-
-            if (canPush)
-            {
-                LastPush.Send();
-            }
-            else
-            {
-                LastPush.StartTimeout();
-                buffer.Add(LastPush);
-            }
-        }
-
-        /// <summary>
-        /// Rejoins the channel.
-        /// </summary>
-        /// <param name="timeoutMs"></param>
-        public void Rejoin(int timeoutMs = Constants.DEFAULT_TIMEOUT)
-        {
-            if (IsLeaving) return;
-            SendJoin(timeoutMs);
-        }
-
-        private void HandleRejoinTimerElapsed(object sender, ElapsedEventArgs e)
-        {
-            if (isRejoining) return;
-            isRejoining = true;
-
-            if (State != ChannelState.Closed && State != ChannelState.Errored)
-                return;
-
-            Client.Instance.Options.Logger?.Invoke(Topic, "attempting to rejoin", null);
-
-            // Reset join push instance
-            JoinPush = new Push(this, Constants.CHANNEL_EVENT_JOIN, Parameters);
-
-            Rejoin();
-        }
-
-        private void SendJoin(int timeoutMs = Constants.DEFAULT_TIMEOUT)
-        {
-            SetState(ChannelState.Joining);
-
-            // Remove handler if exists
-            JoinPush.OnMessage -= HandleJoinResponse;
-
-            JoinPush.OnMessage += HandleJoinResponse;
-            JoinPush.Resend(timeoutMs);
-        }
-
-        private void HandleJoinResponse(object sender, SocketResponseEventArgs args)
-        {
-            if (args.Response._event == Constants.CHANNEL_EVENT_REPLY)
-            {
-                var obj = JsonConvert.DeserializeObject<PheonixResponse>(JsonConvert.SerializeObject(args.Response.Payload, Client.Instance.SerializerSettings), Client.Instance.SerializerSettings);
-                if (obj.Status == Constants.PHEONIX_STATUS_OK)
-                {
-                    SetState(ChannelState.Joined);
-
-                    // Disable Rejoin Timeout
-                    rejoinTimer?.Stop();
-                    isRejoining = false;
-                } else if (obj.Status == Constants.PHEONIX_STATUS_ERROR)
-                {
-                    SetState(ChannelState.Errored);
-
-                    rejoinTimer.Stop();
-                    isRejoining = false;
-                }
-            }
-        }
-
-        private void SetState(ChannelState state)
-        {
-            State = state;
-            StateChanged?.Invoke(this, new ChannelStateChangedEventArgs(state));
-        }
-
-        internal void HandleSocketMessage(SocketResponseEventArgs args)
-        {
-            if (args.Response.Ref == JoinPush.Ref) return;
-
-            // If we don't ignore this event we'll end up with double callbacks.
-            if (args.Response._event == "*") return;
-
-            OnMessage?.Invoke(this, args);
-
-            switch (args.Response.Event)
-            {
-                case Constants.EventType.Insert:
-                    OnInsert?.Invoke(this, args);
-                    break;
-                case Constants.EventType.Update:
-                    OnUpdate?.Invoke(this, args);
-                    break;
-                case Constants.EventType.Delete:
-                    OnDelete?.Invoke(this, args);
-                    break;
-            }
-        }
-
-        private void TriggerChannelStateEvent(ChannelStateChangedEventArgs args, bool shouldRejoin = true)
-        {
-            SetState(args.State);
-
-            if (shouldRejoin)
-            {
-                isRejoining = false;
-                rejoinTimer.Start();
-            }
-            else rejoinTimer.Stop();
-
-            switch (args.State)
-            {
-                case ChannelState.Closed:
-                    OnClose?.Invoke(this, args);
-                    break;
-                case ChannelState.Errored:
-                    OnError?.Invoke(this, args);
-                    break;
-                default:
-                    break;
-            }
-        }
+      [MapTo("closed")]
+      Closed,
+      [MapTo("errored")]
+      Errored,
+      [MapTo("joined")]
+      Joined,
+      [MapTo("joining")]
+      Joining,
+      [MapTo("leaving")]
+      Leaving
     }
 
-    public class ChannelStateChangedEventArgs : EventArgs
-    {
-        public ChannelState State { get; private set; }
+    /// <summary>
+    /// Invoked when the `INSERT` event is raised.
+    /// </summary>
+    public event EventHandler<SocketResponseEventArgs> OnInsert;
 
-        public ChannelStateChangedEventArgs(ChannelState state)
+    /// <summary>
+    /// Invoked when the `UPDATE` event is raised.
+    /// </summary>
+    public event EventHandler<SocketResponseEventArgs> OnUpdate;
+
+    /// <summary>
+    /// Invoked when the `DELETE` event is raised.
+    /// </summary>
+    public event EventHandler<SocketResponseEventArgs> OnDelete;
+
+    /// <summary>
+    /// Invoked anytime a message is decoded within this topic.
+    /// </summary>
+    public event EventHandler<SocketResponseEventArgs> OnMessage;
+
+    /// <summary>
+    /// Invoked when this channel listener is closed
+    /// </summary>
+    public event EventHandler<ChannelStateChangedEventArgs> StateChanged;
+
+    /// <summary>
+    /// Invoked when the socket drops or crashes.
+    /// </summary>
+    public event EventHandler<ChannelStateChangedEventArgs> OnError;
+
+    /// <summary>
+    /// Invoked when the channel is explicitly closed by the client.
+    /// </summary>
+    public event EventHandler<ChannelStateChangedEventArgs> OnClose;
+
+    public bool IsClosed => State == ChannelState.Closed;
+    public bool IsErrored => State == ChannelState.Errored;
+    public bool IsJoined => State == ChannelState.Joined;
+    public bool IsJoining => State == ChannelState.Joining;
+    public bool IsLeaving => State == ChannelState.Leaving;
+
+    /// <summary>
+    /// Shorthand accessor for the Client's socket connection.
+    /// </summary>
+    public Socket Socket { get => Client.Instance.Socket; }
+
+    /// <summary>
+    /// The Channel's current state.
+    /// </summary>
+    public ChannelState State { get; private set; } = ChannelState.Closed;
+
+    /// <summary>
+    /// Channel Parameters, passed on the Join Push.
+    /// </summary>
+    public Dictionary<string, string> Parameters = new Dictionary<string, string>();
+
+    /// <summary>
+    /// The Channel's (unique) topic indentifier.
+    /// </summary>
+    public string Topic { get => Utils.GenerateChannelTopic(database, schema, table, col, value); }
+
+    /// <summary>
+    /// Flag stating whether a channel has been joined once or not.
+    /// </summary>
+    public bool HasJoinedOnce { get; private set; }
+
+    private string database;
+    private string schema;
+    private string table;
+    private string col;
+    private string value;
+
+    /// <summary>
+    /// The initial request to join a channel (repeated on channel disconnect)
+    /// </summary>
+    internal Push JoinPush;
+    internal Push LastPush;
+
+    /// <summary>
+    /// Buffer of Pushes held because of Socket availablity
+    /// </summary>
+    internal List<Push> buffer = new List<Push>();
+
+    private bool canPush => IsJoined && Socket.IsConnected;
+    private bool hasJoinedOnce = false;
+    private Timer rejoinTimer;
+    private bool isRejoining = false;
+
+    /// <summary>
+    /// Initializes a Channel - must call `Subscribe()` to receive events.
+    /// </summary>
+    /// <param name="database"></param>
+    /// <param name="schema"></param>
+    /// <param name="table"></param>
+    /// <param name="col"></param>
+    /// <param name="value"></param>
+    public Channel(string database, string schema, string table, string col, string value, Dictionary<string, string> parameters = null)
+    {
+      if (parameters == null)
+      {
+        parameters = new Dictionary<string, string>();
+      }
+
+      Parameters = parameters;
+
+      this.database = database;
+      this.schema = schema;
+      this.table = table;
+
+      this.col = col;
+      this.value = value;
+
+      JoinPush = new Push(this, Constants.CHANNEL_EVENT_JOIN, Parameters);
+
+      rejoinTimer = new Timer(Client.Instance.Options.Timeout.TotalMilliseconds);
+      rejoinTimer.Elapsed += HandleRejoinTimerElapsed;
+      rejoinTimer.AutoReset = true;
+    }
+
+    /// <summary>
+    /// Subscribes to the channel given supplied options/params.
+    /// </summary>
+    /// <param name="timeoutMs"></param>
+    public Task<Channel> Subscribe(int timeoutMs = Constants.DEFAULT_TIMEOUT)
+    {
+      var tsc = new TaskCompletionSource<Channel>();
+
+      if (hasJoinedOnce)
+      {
+        tsc.SetException(new Exception("`Subscribe` can only be called a single time per channel instance."));
+        return tsc.Task;
+      }
+
+      EventHandler<ChannelStateChangedEventArgs> channelCallback = null;
+      EventHandler joinPushTimeoutCallback = null;
+
+      channelCallback = (object sender, ChannelStateChangedEventArgs e) =>
+      {
+        switch (e.State)
         {
-            State = state;
+          // Success!
+          case ChannelState.Joined:
+            HasJoinedOnce = true;
+            StateChanged -= channelCallback;
+            JoinPush.OnTimeout -= joinPushTimeoutCallback;
+
+            // Clear buffer
+            foreach (var item in buffer)
+              item.Send();
+            buffer.Clear();
+
+            tsc.TrySetResult(this);
+            break;
+          // Failure
+          case ChannelState.Closed:
+          case ChannelState.Errored:
+            StateChanged -= channelCallback;
+            JoinPush.OnTimeout -= joinPushTimeoutCallback;
+
+            tsc.TrySetException(new Exception("Error occurred connecting to channel. Check logs."));
+            break;
         }
+      };
+
+      // Throw an exception if there is a problem receiving a join response
+      joinPushTimeoutCallback = (object sender, EventArgs e) =>
+      {
+        StateChanged -= channelCallback;
+        JoinPush.OnTimeout -= joinPushTimeoutCallback;
+
+        tsc.TrySetException(new PushTimeoutException());
+      };
+
+      StateChanged += channelCallback;
+
+      // Set a flag to prevent multiple join attempts.
+      hasJoinedOnce = true;
+
+      // Init and send join.
+      Rejoin(timeoutMs);
+      JoinPush.OnTimeout += joinPushTimeoutCallback;
+
+      return tsc.Task;
     }
 
-    public class PheonixResponse
+    /// <summary>
+    /// Unsubscribes from the channel.
+    /// </summary>
+    public void Unsubscribe()
     {
-        [JsonProperty("response")]
-        public object Response;
+      SetState(ChannelState.Leaving);
 
-        [JsonProperty("status")]
-        public string Status;
+      var leavePush = new Push(this, Constants.CHANNEL_EVENT_LEAVE, null);
+      leavePush.Send();
+
+      TriggerChannelStateEvent(new ChannelStateChangedEventArgs(ChannelState.Closed));
     }
+
+    /// <summary>
+    /// Sends a `Push` request under this channel.
+    ///
+    /// Maintains a buffer in the event push is called prior to the channel being joined.
+    /// </summary>
+    /// <param name="eventName"></param>
+    /// <param name="payload"></param>
+    /// <param name="timeoutMs"></param>
+    public void Push(string eventName, object payload, int timeoutMs = Constants.DEFAULT_TIMEOUT)
+    {
+      if (!hasJoinedOnce)
+        throw new Exception($"Tried to push '{eventName}' to '{Topic}' before joining. Use `Channel.Subscribe()` before pushing events");
+
+      LastPush = new Push(this, eventName, payload, timeoutMs);
+
+      if (canPush)
+      {
+        LastPush.Send();
+      }
+      else
+      {
+        LastPush.StartTimeout();
+        buffer.Add(LastPush);
+      }
+    }
+
+    /// <summary>
+    /// Rejoins the channel.
+    /// </summary>
+    /// <param name="timeoutMs"></param>
+    public void Rejoin(int timeoutMs = Constants.DEFAULT_TIMEOUT)
+    {
+      if (IsLeaving) return;
+      SendJoin(timeoutMs);
+    }
+
+    private void HandleRejoinTimerElapsed(object sender, ElapsedEventArgs e)
+    {
+      if (isRejoining) return;
+      isRejoining = true;
+
+      if (State != ChannelState.Closed && State != ChannelState.Errored)
+        return;
+
+      Client.Instance.Options.Logger?.Invoke(Topic, "attempting to rejoin", null);
+
+      // Reset join push instance
+      JoinPush = new Push(this, Constants.CHANNEL_EVENT_JOIN, Parameters);
+
+      Rejoin();
+    }
+
+    private void SendJoin(int timeoutMs = Constants.DEFAULT_TIMEOUT)
+    {
+      SetState(ChannelState.Joining);
+
+      // Remove handler if exists
+      JoinPush.OnMessage -= HandleJoinResponse;
+
+      JoinPush.OnMessage += HandleJoinResponse;
+      JoinPush.Resend(timeoutMs);
+    }
+
+    private void HandleJoinResponse(object sender, SocketResponseEventArgs args)
+    {
+      if (args.Response._event == Constants.CHANNEL_EVENT_REPLY)
+      {
+        var obj = JsonConvert.DeserializeObject<PheonixResponse>(JsonConvert.SerializeObject(args.Response.Payload, Client.Instance.SerializerSettings), Client.Instance.SerializerSettings);
+        if (obj.Status == Constants.PHEONIX_STATUS_OK)
+        {
+          SetState(ChannelState.Joined);
+
+          // Disable Rejoin Timeout
+          rejoinTimer?.Stop();
+          isRejoining = false;
+        }
+        else if (obj.Status == Constants.PHEONIX_STATUS_ERROR)
+        {
+          SetState(ChannelState.Errored);
+
+          rejoinTimer.Stop();
+          isRejoining = false;
+        }
+      }
+    }
+
+    private void SetState(ChannelState state)
+    {
+      State = state;
+      StateChanged?.Invoke(this, new ChannelStateChangedEventArgs(state));
+    }
+
+    internal void HandleSocketMessage(SocketResponseEventArgs args)
+    {
+      if (args.Response.Ref == JoinPush.Ref) return;
+
+      // If we don't ignore this event we'll end up with double callbacks.
+      if (args.Response._event == "*") return;
+
+      OnMessage?.Invoke(this, args);
+
+      switch (args.Response.Event)
+      {
+        case Constants.EventType.Insert:
+          OnInsert?.Invoke(this, args);
+          break;
+        case Constants.EventType.Update:
+          OnUpdate?.Invoke(this, args);
+          break;
+        case Constants.EventType.Delete:
+          OnDelete?.Invoke(this, args);
+          break;
+      }
+    }
+
+    private void TriggerChannelStateEvent(ChannelStateChangedEventArgs args, bool shouldRejoin = true)
+    {
+      SetState(args.State);
+
+      if (shouldRejoin)
+      {
+        isRejoining = false;
+        rejoinTimer.Start();
+      }
+      else rejoinTimer.Stop();
+
+      switch (args.State)
+      {
+        case ChannelState.Closed:
+          OnClose?.Invoke(this, args);
+          break;
+        case ChannelState.Errored:
+          OnError?.Invoke(this, args);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  public class ChannelStateChangedEventArgs : EventArgs
+  {
+    public ChannelState State { get; private set; }
+
+    public ChannelStateChangedEventArgs(ChannelState state)
+    {
+      State = state;
+    }
+  }
+
+  public class PheonixResponse
+  {
+    [JsonProperty("response")]
+    public object Response;
+
+    [JsonProperty("status")]
+    public string Status;
+  }
 }

--- a/Realtime/Client.cs
+++ b/Realtime/Client.cs
@@ -2,100 +2,100 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Net.WebSockets;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using WebSocketSharp;
 
 namespace Supabase.Realtime
 {
+  /// <summary>
+  /// Singleton that represents a Client connection to a Realtime Server.
+  ///
+  /// It maintains a singular Websocket with asynchronous listeners (Channels).
+  /// </summary>
+  /// <example>
+  ///     client = Client.Instance
+  /// </example>
+  public class Client
+  {
     /// <summary>
-    /// Singleton that represents a Client connection to a Realtime Server.
+    /// Contains all Realtime Channel Subscriptions - state managed internally.
     ///
-    /// It maintains a singular Websocket with asynchronous listeners (Channels).
+    /// Keys are of encoded value: `{database}{:schema?}{:table?}{:col.eq.:value?}`
+    /// Values are of type `Channel<T> where T : BaseModel, new()`;
     /// </summary>
-    /// <example>
-    ///     client = Client.Instance
-    /// </example>
-    public class Client
+    private Dictionary<string, Channel> subscriptions { get; set; }
+
+    /// <summary>
+    /// Exposes all Realtime Channel Subscriptions for R/O public consumption 
+    /// </summary>
+    public ReadOnlyDictionary<string, Channel> Subscriptions => new ReadOnlyDictionary<string, Channel>(subscriptions);
+
+    /// <summary>
+    /// The backing Socket class.
+    ///
+    /// Most methods of the Client act as proxies to the Socket class.
+    /// </summary>
+    public Socket Socket { get; private set; }
+
+    /// <summary>
+    /// Client Options - most of which are regarding Socket connection options
+    /// </summary>
+    public ClientOptions Options { get; private set; }
+
+    private static Client instance;
+    /// <summary>
+    /// The Client Instance (singleton)
+    /// </summary>
+    public static Client Instance
     {
-        /// <summary>
-        /// Contains all Realtime Channel Subscriptions - state managed internally.
-        ///
-        /// Keys are of encoded value: `{database}{:schema?}{:table?}{:col.eq.:value?}`
-        /// Values are of type `Channel<T> where T : BaseModel, new()`;
-        /// </summary>
-        private Dictionary<string, Channel> subscriptions { get; set; }
+      get
+      {
+        if (instance == null)
+          instance = new Client();
 
-        /// <summary>
-        /// Exposes all Realtime Channel Subscriptions for R/O public consumption 
-        /// </summary>
-        public ReadOnlyDictionary<string, Channel> Subscriptions => new ReadOnlyDictionary<string, Channel>(subscriptions);
+        return instance;
+      }
+    }
 
-        /// <summary>
-        /// The backing Socket class.
-        ///
-        /// Most methods of the Client act as proxies to the Socket class.
-        /// </summary>
-        public Socket Socket { get; private set; }
+    /// <summary>
+    /// Invoked when the socket raises the `open` event.
+    /// </summary>
+    public event EventHandler<SocketStateChangedEventArgs> OnOpen;
 
-        /// <summary>
-        /// Client Options - most of which are regarding Socket connection options
-        /// </summary>
-        public ClientOptions Options { get; private set; }
+    /// <summary>
+    /// Invoked when the socket raises the `close` event.
+    /// </summary>
+    public event EventHandler<SocketStateChangedEventArgs> OnClose;
 
-        private static Client instance;
-        /// <summary>
-        /// The Client Instance (singleton)
-        /// </summary>
-        public static Client Instance
+    /// <summary>
+    /// Invoked when the socket raises the `error` event.
+    /// </summary>
+    public event EventHandler<SocketStateChangedEventArgs> OnError;
+
+    /// <summary>
+    /// Invoked when the socket raises the `message` event.
+    /// </summary>
+    public event EventHandler<SocketStateChangedEventArgs> OnMessage;
+
+    /// <summary>
+    /// Custom Serializer resolvers and converters that will be used for encoding and decoding Postgrest JSON responses.
+    ///
+    /// By default, Postgrest seems to use a date format that C# and Newtonsoft do not like, so this initial
+    /// configuration handles that.
+    /// </summary>
+    public JsonSerializerSettings SerializerSettings
+    {
+      get
+      {
+        if (Options == null)
+          Options = new ClientOptions();
+
+        return new JsonSerializerSettings
         {
-            get
-            {
-                if (instance == null)
-                    instance = new Client();
-
-                return instance;
-            }
-        }
-
-        /// <summary>
-        /// Invoked when the socket raises the `open` event.
-        /// </summary>
-        public event EventHandler<SocketStateChangedEventArgs> OnOpen;
-
-        /// <summary>
-        /// Invoked when the socket raises the `close` event.
-        /// </summary>
-        public event EventHandler<SocketStateChangedEventArgs> OnClose;
-
-        /// <summary>
-        /// Invoked when the socket raises the `error` event.
-        /// </summary>
-        public event EventHandler<SocketStateChangedEventArgs> OnError;
-
-        /// <summary>
-        /// Invoked when the socket raises the `message` event.
-        /// </summary>
-        public event EventHandler<SocketStateChangedEventArgs> OnMessage;
-
-        /// <summary>
-        /// Custom Serializer resolvers and converters that will be used for encoding and decoding Postgrest JSON responses.
-        ///
-        /// By default, Postgrest seems to use a date format that C# and Newtonsoft do not like, so this initial
-        /// configuration handles that.
-        /// </summary>
-        public JsonSerializerSettings SerializerSettings
-        {
-            get
-            {
-                if (Options == null)
-                    Options = new ClientOptions();
-
-                return new JsonSerializerSettings
-                {
-                    ContractResolver = new CustomContractResolver(),
-                    Converters =
+          ContractResolver = new CustomContractResolver(),
+          Converters =
                     {
                         // 2020-08-28T12:01:54.763231
                         new IsoDateTimeConverter
@@ -104,254 +104,254 @@ namespace Supabase.Realtime
                             DateTimeFormat = Options.DateTimeFormat,
                         }
                     },
-                    DateFormatHandling = DateFormatHandling.IsoDateFormat,
-                    DateParseHandling = Newtonsoft.Json.DateParseHandling.DateTimeOffset
-                };
-            }
+          DateFormatHandling = DateFormatHandling.IsoDateFormat,
+          DateParseHandling = Newtonsoft.Json.DateParseHandling.DateTimeOffset
+        };
+      }
+    }
+
+    private string realtimeUrl;
+
+    /// <summary>
+    /// JWT Access token for WALRUS security
+    /// </summary>
+    internal string AccessToken { get; private set; }
+
+    /// <summary>
+    /// Initializes a Client instance, this method should be called prior to any other method.
+    /// </summary>
+    /// <param name="realtimeUrl">The connection url (ex: "ws://localhost:4000/socket" - no trailing slash required)</param>
+    /// <param name="options"></param>
+    /// <returns>Client</returns>
+    public static Client Initialize(string realtimeUrl, ClientOptions options = null)
+    {
+      instance = new Client();
+      instance.realtimeUrl = realtimeUrl;
+
+      if (options == null)
+      {
+        options = new ClientOptions();
+      }
+
+      instance.Options = options;
+      instance.subscriptions = new Dictionary<string, Channel>();
+
+      return instance;
+    }
+
+    /// <summary>
+    /// Attempts to connect to the socket given the params specified in `Initialize`
+    ///
+    /// Returns when socket has successfully connected.
+    /// </summary>
+    /// <returns></returns>
+    public Task<Client> ConnectAsync()
+    {
+      var tsc = new TaskCompletionSource<Client>();
+
+      try
+      {
+        if (Socket != null)
+        {
+          Debug.WriteLine("Socket already exists.");
+
+          tsc.TrySetResult(this);
+
+          return tsc.Task;
         }
 
-        private string realtimeUrl;
-
-        /// <summary>
-        /// JWT Access token for WALRUS security
-        /// </summary>
-        internal string AccessToken { get; private set; }
-
-        /// <summary>
-        /// Initializes a Client instance, this method should be called prior to any other method.
-        /// </summary>
-        /// <param name="realtimeUrl">The connection url (ex: "ws://localhost:4000/socket" - no trailing slash required)</param>
-        /// <param name="options"></param>
-        /// <returns>Client</returns>
-        public static Client Initialize(string realtimeUrl, ClientOptions options = null)
+        EventHandler<SocketStateChangedEventArgs> callback = null;
+        callback = (object sender, SocketStateChangedEventArgs args) =>
         {
-            instance = new Client();
-            instance.realtimeUrl = realtimeUrl;
+          switch (args.State)
+          {
+            case SocketStateChangedEventArgs.ConnectionState.Open:
+              Socket.StateChanged -= callback;
+              tsc.TrySetResult(this);
+              break;
+            case SocketStateChangedEventArgs.ConnectionState.Close:
+            case SocketStateChangedEventArgs.ConnectionState.Error:
+              Socket.StateChanged -= callback;
+              tsc.TrySetException(new Exception("Error occurred connecting to Socket. Check logs."));
+              break;
+          }
+        };
 
-            if (options == null)
-            {
-                options = new ClientOptions();
-            }
+        Socket = new Socket(realtimeUrl, Options);
 
-            instance.Options = options;
-            instance.subscriptions = new Dictionary<string, Channel>();
+        Socket.StateChanged += HandleSocketStateChanged;
+        Socket.OnMessage += HandleSocketMessage;
 
-            return instance;
+        Socket.StateChanged += callback;
+        Socket.Connect();
+      }
+      catch (Exception ex)
+      {
+        tsc.TrySetException(ex);
+      }
+
+      return tsc.Task;
+    }
+
+    /// <summary>
+    /// Attempts to connect to the socket given the params specified in `Initialize`
+    ///
+    /// Provides a callback for `Task` driven returns.
+    /// </summary>
+    /// <param name="callback"></param>
+    /// <returns></returns>
+    public Client Connect(Action<Client> callback = null)
+    {
+      if (Socket != null)
+      {
+        Debug.WriteLine("Socket already exists.");
+        return this;
+      }
+
+      EventHandler<SocketStateChangedEventArgs> cb = null;
+      cb = (object sender, SocketStateChangedEventArgs args) =>
+      {
+        switch (args.State)
+        {
+          case SocketStateChangedEventArgs.ConnectionState.Open:
+            Socket.StateChanged -= cb;
+            callback?.Invoke(this);
+            break;
+          case SocketStateChangedEventArgs.ConnectionState.Close:
+          case SocketStateChangedEventArgs.ConnectionState.Error:
+            Socket.StateChanged -= cb;
+            throw new Exception("Error occurred connecting to Socket. Check logs.");
         }
+      };
 
-        /// <summary>
-        /// Attempts to connect to the socket given the params specified in `Initialize`
-        ///
-        /// Returns when socket has successfully connected.
-        /// </summary>
-        /// <returns></returns>
-        public Task<Client> ConnectAsync()
+      Socket = new Socket(realtimeUrl, Options);
+
+      Socket.StateChanged += HandleSocketStateChanged;
+      Socket.OnMessage += HandleSocketMessage;
+
+      Socket.StateChanged += cb;
+      Socket.Connect();
+
+      return this;
+    }
+
+    /// <summary>
+    /// Disconnects from the socket server (if connected).
+    /// </summary>
+    /// <param name="code">Status Code</param>
+    /// <param name="reason">Reason for disconnect</param>
+    /// <returns></returns>
+    public Client Disconnect(WebSocketCloseStatus code = WebSocketCloseStatus.NormalClosure, string reason = "Programmatic Disconnect")
+    {
+      if (Socket != null)
+      {
+        Socket.StateChanged -= HandleSocketStateChanged;
+        Socket.OnMessage -= HandleSocketMessage;
+        Socket.Disconnect(code, reason);
+        Socket = null;
+      }
+      return this;
+    }
+
+    /// <summary>
+    /// Sets the JWT access token used for channel subscription authorization and Realtime RLS.
+    /// Ref: https://github.com/supabase/realtime-js/pull/117 | https://github.com/supabase/realtime-js/pull/117
+    /// </summary>
+    /// <param name="jwt"></param>
+    public void SetAuth(string jwt)
+    {
+      AccessToken = jwt;
+
+      try
+      {
+        foreach (var channel in subscriptions.Values)
         {
-            var tsc = new TaskCompletionSource<Client>();
+          // See: https://github.com/supabase/realtime-js/pull/126
+          channel.Parameters["user_token"] = AccessToken;
 
-            try
-            {
-                if (Socket != null)
-                {
-                    Debug.WriteLine("Socket already exists.");
-
-                    tsc.TrySetResult(this);
-
-                    return tsc.Task;
-                }
-
-                EventHandler<SocketStateChangedEventArgs> callback = null;
-                callback = (object sender, SocketStateChangedEventArgs args) =>
-                {
-                    switch (args.State)
-                    {
-                        case SocketStateChangedEventArgs.ConnectionState.Open:
-                            Socket.StateChanged -= callback;
-                            tsc.TrySetResult(this);
-                            break;
-                        case SocketStateChangedEventArgs.ConnectionState.Close:
-                        case SocketStateChangedEventArgs.ConnectionState.Error:
-                            Socket.StateChanged -= callback;
-                            tsc.TrySetException(new Exception("Error occurred connecting to Socket. Check logs."));
-                            break;
-                    }
-                };
-
-                Socket = new Socket(realtimeUrl, Options);
-
-                Socket.StateChanged += HandleSocketStateChanged;
-                Socket.OnMessage += HandleSocketMessage;
-
-                Socket.StateChanged += callback;
-                Socket.Connect();
-            }
-            catch (Exception ex)
-            {
-                tsc.TrySetException(ex);
-            }
-
-            return tsc.Task;
-        }
-
-        /// <summary>
-        /// Attempts to connect to the socket given the params specified in `Initialize`
-        ///
-        /// Provides a callback for `Task` driven returns.
-        /// </summary>
-        /// <param name="callback"></param>
-        /// <returns></returns>
-        public Client Connect(Action<Client> callback = null)
-        {
-            if (Socket != null)
-            {
-                Debug.WriteLine("Socket already exists.");
-                return this;
-            }
-
-            EventHandler<SocketStateChangedEventArgs> cb = null;
-            cb = (object sender, SocketStateChangedEventArgs args) =>
-            {
-                switch (args.State)
-                {
-                    case SocketStateChangedEventArgs.ConnectionState.Open:
-                        Socket.StateChanged -= cb;
-                        callback?.Invoke(this);
-                        break;
-                    case SocketStateChangedEventArgs.ConnectionState.Close:
-                    case SocketStateChangedEventArgs.ConnectionState.Error:
-                        Socket.StateChanged -= cb;
-                        throw new Exception("Error occurred connecting to Socket. Check logs.");
-                }
-            };
-
-            Socket = new Socket(realtimeUrl, Options);
-
-            Socket.StateChanged += HandleSocketStateChanged;
-            Socket.OnMessage += HandleSocketMessage;
-
-            Socket.StateChanged += cb;
-            Socket.Connect();
-
-            return this;
-        }
-
-        /// <summary>
-        /// Disconnects from the socket server (if connected).
-        /// </summary>
-        /// <param name="code">Status Code</param>
-        /// <param name="reason">Reason for disconnect</param>
-        /// <returns></returns>
-        public Client Disconnect(CloseStatusCode code = WebSocketSharp.CloseStatusCode.Normal, string reason = "Programmatic Disconnect")
-        {
-            if (Socket != null)
-            {
-                Socket.StateChanged -= HandleSocketStateChanged;
-                Socket.OnMessage -= HandleSocketMessage;
-                Socket.Disconnect(code, reason);
-                Socket = null;
-            }
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the JWT access token used for channel subscription authorization and Realtime RLS.
-        /// Ref: https://github.com/supabase/realtime-js/pull/117 | https://github.com/supabase/realtime-js/pull/117
-        /// </summary>
-        /// <param name="jwt"></param>
-        public void SetAuth(string jwt)
-        {
-            AccessToken = jwt;
-
-            try
-            {
-                foreach (var channel in subscriptions.Values)
-                {
-                    // See: https://github.com/supabase/realtime-js/pull/126
-                    channel.Parameters["user_token"] = AccessToken;
-
-                    if (channel.HasJoinedOnce && channel.IsJoined)
-                    {
-                        channel.Push(Constants.CHANNEL_ACCESS_TOKEN, new Dictionary<string, string>
+          if (channel.HasJoinedOnce && channel.IsJoined)
+          {
+            channel.Push(Constants.CHANNEL_ACCESS_TOKEN, new Dictionary<string, string>
                         {
                             { "access_token", AccessToken }
                         });
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex);
-            }
+          }
         }
-
-        /// <summary>
-        /// Adds a Channel subscription - if a subscription exists with the same signature, the existing subscription will be returned.
-        /// </summary>
-        /// <param name="database">Database to connect to, with Supabase this will likely be `realtime`.</param>
-        /// <param name="schema">Postgres schema, for example, `public`</param>
-        /// <param name="table">Postgres table name</param>
-        /// <param name="column">Postgres column name</param>
-        /// <param name="value">Value the specified column should have</param>
-        /// <returns></returns>
-        public Channel Channel(string database = "realtime", string schema = null, string table = null, string column = null, string value = null, Dictionary<string, string> parameters = null)
-        {
-            var key = Utils.GenerateChannelTopic(database, schema, table, column, value);
-
-            if (subscriptions.ContainsKey(key))
-            {
-                return subscriptions[key];
-            }
-
-            var subscription = new Channel(database, schema, table, column, value, parameters);
-            subscriptions.Add(key, subscription);
-
-            return subscription;
-        }
-
-        /// <summary>
-        /// Removes a channel subscription.
-        /// </summary>
-        /// <param name="channel"></param>
-        public void Remove(Channel channel)
-        {
-            if (subscriptions.ContainsKey(channel.Topic))
-            {
-                if (channel.IsJoined)
-                    channel.Unsubscribe();
-
-                subscriptions.Remove(channel.Topic);
-            }
-        }
-
-        private void HandleSocketMessage(object sender, SocketResponseEventArgs args)
-        {
-            if (subscriptions.ContainsKey(args.Response.Topic))
-            {
-                subscriptions[args.Response.Topic].HandleSocketMessage(args);
-            }
-        }
-
-        private void HandleSocketStateChanged(object sender, SocketStateChangedEventArgs args)
-        {
-            Options.Logger("socket", "state changed", args.State);
-            switch (args.State)
-            {
-                case SocketStateChangedEventArgs.ConnectionState.Open:
-                    // Ref: https://github.com/supabase/realtime-js/pull/116/files
-                    SetAuth(AccessToken);
-
-                    OnOpen?.Invoke(this, args);
-                    break;
-                case SocketStateChangedEventArgs.ConnectionState.Close:
-                    OnClose?.Invoke(this, args);
-                    break;
-                case SocketStateChangedEventArgs.ConnectionState.Error:
-                    OnError?.Invoke(this, args);
-                    break;
-                case SocketStateChangedEventArgs.ConnectionState.Message:
-                    OnMessage?.Invoke(this, args);
-                    break;
-            }
-        }
+      }
+      catch (Exception ex)
+      {
+        Debug.WriteLine(ex);
+      }
     }
+
+    /// <summary>
+    /// Adds a Channel subscription - if a subscription exists with the same signature, the existing subscription will be returned.
+    /// </summary>
+    /// <param name="database">Database to connect to, with Supabase this will likely be `realtime`.</param>
+    /// <param name="schema">Postgres schema, for example, `public`</param>
+    /// <param name="table">Postgres table name</param>
+    /// <param name="column">Postgres column name</param>
+    /// <param name="value">Value the specified column should have</param>
+    /// <returns></returns>
+    public Channel Channel(string database = "realtime", string schema = null, string table = null, string column = null, string value = null, Dictionary<string, string> parameters = null)
+    {
+      var key = Utils.GenerateChannelTopic(database, schema, table, column, value);
+
+      if (subscriptions.ContainsKey(key))
+      {
+        return subscriptions[key];
+      }
+
+      var subscription = new Channel(database, schema, table, column, value, parameters);
+      subscriptions.Add(key, subscription);
+
+      return subscription;
+    }
+
+    /// <summary>
+    /// Removes a channel subscription.
+    /// </summary>
+    /// <param name="channel"></param>
+    public void Remove(Channel channel)
+    {
+      if (subscriptions.ContainsKey(channel.Topic))
+      {
+        if (channel.IsJoined)
+          channel.Unsubscribe();
+
+        subscriptions.Remove(channel.Topic);
+      }
+    }
+
+    private void HandleSocketMessage(object sender, SocketResponseEventArgs args)
+    {
+      if (subscriptions.ContainsKey(args.Response.Topic))
+      {
+        subscriptions[args.Response.Topic].HandleSocketMessage(args);
+      }
+    }
+
+    private void HandleSocketStateChanged(object sender, SocketStateChangedEventArgs args)
+    {
+      Options.Logger("socket", "state changed", args.State);
+      switch (args.State)
+      {
+        case SocketStateChangedEventArgs.ConnectionState.Open:
+          // Ref: https://github.com/supabase/realtime-js/pull/116/files
+          SetAuth(AccessToken);
+
+          OnOpen?.Invoke(this, args);
+          break;
+        case SocketStateChangedEventArgs.ConnectionState.Close:
+          OnClose?.Invoke(this, args);
+          break;
+        case SocketStateChangedEventArgs.ConnectionState.Error:
+          OnError?.Invoke(this, args);
+          break;
+        case SocketStateChangedEventArgs.ConnectionState.Message:
+          OnMessage?.Invoke(this, args);
+          break;
+      }
+    }
+  }
 }

--- a/Realtime/Push.cs
+++ b/Realtime/Push.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Timers;
-using Newtonsoft.Json;
-using WebSocketSharp;
 
 namespace Supabase.Realtime
 {

--- a/Realtime/Realtime.csproj
+++ b/Realtime/Realtime.csproj
@@ -28,7 +28,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="postgrest-csharp" Version="2.0.6" />
-		<PackageReference Include="WebSocketSharp-netstandard" Version="1.0.1" />
+		<PackageReference Include="Websocket.Client" Version="4.4.43" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
Changes the WebSocketSharp library for [https://github.com/Marfusios/websocket-client](https://github.com/Marfusios/websocket-client). This is so the real-time package can be used in Blazor WASM apps.

The previous library used a library (System.Security.Cryptography.Csp) which is no longer supported by Blazor in the browser:
[https://docs.microsoft.com/en-us/dotnet/core/compatibility/cryptography/5.0/cryptography-apis-not-supported-on-blazor-webassembly](https://docs.microsoft.com/en-us/dotnet/core/compatibility/cryptography/5.0/cryptography-apis-not-supported-on-blazor-webassembly)