### PR TITLE
Restructure Project to support Dependency Injection

### DIFF
--- a/Realtime/Attributes/MapToAttribute.cs
+++ b/Realtime/Attributes/MapToAttribute.cs
@@ -10,9 +10,9 @@ namespace Supabase.Realtime.Attributes
     internal class MapToAttribute : Attribute
     {
         public string Mapping { get; set; }
-        public string Formatter { get; set; }
+        public string? Formatter { get; set; }
 
-        public MapToAttribute(string mapping, string formatter = null)
+        public MapToAttribute(string mapping, string? formatter = null)
         {
             Mapping = mapping;
             Formatter = formatter;

--- a/Realtime/Channel.cs
+++ b/Realtime/Channel.cs
@@ -10,382 +10,371 @@ using static Supabase.Realtime.Channel;
 [assembly: InternalsVisibleTo("RealtimeTests")]
 namespace Supabase.Realtime
 {
-  /// <summary>
-  /// Class representation of a channel subscription
-  /// </summary>
-  public class Channel
-  {
     /// <summary>
-    /// Channel state with associated string representations.
+    /// Class representation of a channel subscription
     /// </summary>
-    public enum ChannelState
+    public class Channel
     {
-      [MapTo("closed")]
-      Closed,
-      [MapTo("errored")]
-      Errored,
-      [MapTo("joined")]
-      Joined,
-      [MapTo("joining")]
-      Joining,
-      [MapTo("leaving")]
-      Leaving
-    }
-
-    /// <summary>
-    /// Invoked when the `INSERT` event is raised.
-    /// </summary>
-    public event EventHandler<SocketResponseEventArgs> OnInsert;
-
-    /// <summary>
-    /// Invoked when the `UPDATE` event is raised.
-    /// </summary>
-    public event EventHandler<SocketResponseEventArgs> OnUpdate;
-
-    /// <summary>
-    /// Invoked when the `DELETE` event is raised.
-    /// </summary>
-    public event EventHandler<SocketResponseEventArgs> OnDelete;
-
-    /// <summary>
-    /// Invoked anytime a message is decoded within this topic.
-    /// </summary>
-    public event EventHandler<SocketResponseEventArgs> OnMessage;
-
-    /// <summary>
-    /// Invoked when this channel listener is closed
-    /// </summary>
-    public event EventHandler<ChannelStateChangedEventArgs> StateChanged;
-
-    /// <summary>
-    /// Invoked when the socket drops or crashes.
-    /// </summary>
-    public event EventHandler<ChannelStateChangedEventArgs> OnError;
-
-    /// <summary>
-    /// Invoked when the channel is explicitly closed by the client.
-    /// </summary>
-    public event EventHandler<ChannelStateChangedEventArgs> OnClose;
-
-    public bool IsClosed => State == ChannelState.Closed;
-    public bool IsErrored => State == ChannelState.Errored;
-    public bool IsJoined => State == ChannelState.Joined;
-    public bool IsJoining => State == ChannelState.Joining;
-    public bool IsLeaving => State == ChannelState.Leaving;
-
-    /// <summary>
-    /// Shorthand accessor for the Client's socket connection.
-    /// </summary>
-    public Socket Socket { get => Client.Instance.Socket; }
-
-    /// <summary>
-    /// The Channel's current state.
-    /// </summary>
-    public ChannelState State { get; private set; } = ChannelState.Closed;
-
-    /// <summary>
-    /// Channel Parameters, passed on the Join Push.
-    /// </summary>
-    public Dictionary<string, string> Parameters = new Dictionary<string, string>();
-
-    /// <summary>
-    /// The Channel's (unique) topic indentifier.
-    /// </summary>
-    public string Topic { get => Utils.GenerateChannelTopic(database, schema, table, col, value); }
-
-    /// <summary>
-    /// Flag stating whether a channel has been joined once or not.
-    /// </summary>
-    public bool HasJoinedOnce { get; private set; }
-
-    private string database;
-    private string schema;
-    private string table;
-    private string col;
-    private string value;
-
-    /// <summary>
-    /// The initial request to join a channel (repeated on channel disconnect)
-    /// </summary>
-    internal Push JoinPush;
-    internal Push LastPush;
-
-    /// <summary>
-    /// Buffer of Pushes held because of Socket availablity
-    /// </summary>
-    internal List<Push> buffer = new List<Push>();
-
-    private bool canPush => IsJoined && Socket.IsConnected;
-    private bool hasJoinedOnce = false;
-    private Timer rejoinTimer;
-    private bool isRejoining = false;
-
-    /// <summary>
-    /// Initializes a Channel - must call `Subscribe()` to receive events.
-    /// </summary>
-    /// <param name="database"></param>
-    /// <param name="schema"></param>
-    /// <param name="table"></param>
-    /// <param name="col"></param>
-    /// <param name="value"></param>
-    public Channel(string database, string schema, string table, string col, string value, Dictionary<string, string> parameters = null)
-    {
-      if (parameters == null)
-      {
-        parameters = new Dictionary<string, string>();
-      }
-
-      Parameters = parameters;
-
-      this.database = database;
-      this.schema = schema;
-      this.table = table;
-
-      this.col = col;
-      this.value = value;
-
-      JoinPush = new Push(this, Constants.CHANNEL_EVENT_JOIN, Parameters);
-
-      rejoinTimer = new Timer(Client.Instance.Options.Timeout.TotalMilliseconds);
-      rejoinTimer.Elapsed += HandleRejoinTimerElapsed;
-      rejoinTimer.AutoReset = true;
-    }
-
-    /// <summary>
-    /// Subscribes to the channel given supplied options/params.
-    /// </summary>
-    /// <param name="timeoutMs"></param>
-    public Task<Channel> Subscribe(int timeoutMs = Constants.DEFAULT_TIMEOUT)
-    {
-      var tsc = new TaskCompletionSource<Channel>();
-
-      if (hasJoinedOnce)
-      {
-        tsc.SetException(new Exception("`Subscribe` can only be called a single time per channel instance."));
-        return tsc.Task;
-      }
-
-      EventHandler<ChannelStateChangedEventArgs> channelCallback = null;
-      EventHandler joinPushTimeoutCallback = null;
-
-      channelCallback = (object sender, ChannelStateChangedEventArgs e) =>
-      {
-        switch (e.State)
+        /// <summary>
+        /// Channel state with associated string representations.
+        /// </summary>
+        public enum ChannelState
         {
-          // Success!
-          case ChannelState.Joined:
-            HasJoinedOnce = true;
-            StateChanged -= channelCallback;
-            JoinPush.OnTimeout -= joinPushTimeoutCallback;
-
-            // Clear buffer
-            foreach (var item in buffer)
-              item.Send();
-            buffer.Clear();
-
-            tsc.TrySetResult(this);
-            break;
-          // Failure
-          case ChannelState.Closed:
-          case ChannelState.Errored:
-            StateChanged -= channelCallback;
-            JoinPush.OnTimeout -= joinPushTimeoutCallback;
-
-            tsc.TrySetException(new Exception("Error occurred connecting to channel. Check logs."));
-            break;
+            [MapTo("closed")]
+            Closed,
+            [MapTo("errored")]
+            Errored,
+            [MapTo("joined")]
+            Joined,
+            [MapTo("joining")]
+            Joining,
+            [MapTo("leaving")]
+            Leaving
         }
-      };
 
-      // Throw an exception if there is a problem receiving a join response
-      joinPushTimeoutCallback = (object sender, EventArgs e) =>
-      {
-        StateChanged -= channelCallback;
-        JoinPush.OnTimeout -= joinPushTimeoutCallback;
+        /// <summary>
+        /// Invoked when the `INSERT` event is raised.
+        /// </summary>
+        public event EventHandler<SocketResponseEventArgs>? OnInsert;
 
-        tsc.TrySetException(new PushTimeoutException());
-      };
+        /// <summary>
+        /// Invoked when the `UPDATE` event is raised.
+        /// </summary>
+        public event EventHandler<SocketResponseEventArgs>? OnUpdate;
 
-      StateChanged += channelCallback;
+        /// <summary>
+        /// Invoked when the `DELETE` event is raised.
+        /// </summary>
+        public event EventHandler<SocketResponseEventArgs>? OnDelete;
 
-      // Set a flag to prevent multiple join attempts.
-      hasJoinedOnce = true;
+        /// <summary>
+        /// Invoked anytime a message is decoded within this topic.
+        /// </summary>
+        public event EventHandler<SocketResponseEventArgs>? OnMessage;
 
-      // Init and send join.
-      Rejoin(timeoutMs);
-      JoinPush.OnTimeout += joinPushTimeoutCallback;
+        /// <summary>
+        /// Invoked when this channel listener is closed
+        /// </summary>
+        public event EventHandler<ChannelStateChangedEventArgs>? StateChanged;
 
-      return tsc.Task;
-    }
+        /// <summary>
+        /// Invoked when the socket drops or crashes.
+        /// </summary>
+        public event EventHandler<ChannelStateChangedEventArgs>? OnError;
 
-    /// <summary>
-    /// Unsubscribes from the channel.
-    /// </summary>
-    public void Unsubscribe()
-    {
-      SetState(ChannelState.Leaving);
+        /// <summary>
+        /// Invoked when the channel is explicitly closed by the client.
+        /// </summary>
+        public event EventHandler<ChannelStateChangedEventArgs>? OnClose;
 
-      var leavePush = new Push(this, Constants.CHANNEL_EVENT_LEAVE, null);
-      leavePush.Send();
+        public bool IsClosed => State == ChannelState.Closed;
+        public bool IsErrored => State == ChannelState.Errored;
+        public bool IsJoined => State == ChannelState.Joined;
+        public bool IsJoining => State == ChannelState.Joining;
+        public bool IsLeaving => State == ChannelState.Leaving;
 
-      TriggerChannelStateEvent(new ChannelStateChangedEventArgs(ChannelState.Closed));
-    }
+        /// <summary>
+        /// The Channel's current state.
+        /// </summary>
+        public ChannelState State { get; private set; } = ChannelState.Closed;
 
-    /// <summary>
-    /// Sends a `Push` request under this channel.
-    ///
-    /// Maintains a buffer in the event push is called prior to the channel being joined.
-    /// </summary>
-    /// <param name="eventName"></param>
-    /// <param name="payload"></param>
-    /// <param name="timeoutMs"></param>
-    public void Push(string eventName, object payload, int timeoutMs = Constants.DEFAULT_TIMEOUT)
-    {
-      if (!hasJoinedOnce)
-        throw new Exception($"Tried to push '{eventName}' to '{Topic}' before joining. Use `Channel.Subscribe()` before pushing events");
+        /// <summary>
+        /// Channel Parameters, passed on the Join Push.
+        /// </summary>
+        public Dictionary<string, string> Parameters = new Dictionary<string, string>();
 
-      LastPush = new Push(this, eventName, payload, timeoutMs);
+        /// <summary>
+        /// The Channel's (unique) topic indentifier.
+        /// </summary>
+        public string Topic { get => Utils.GenerateChannelTopic(options.Database, options.Schema, options.Table, options.Column, options.Value); }
 
-      if (canPush)
-      {
-        LastPush.Send();
-      }
-      else
-      {
-        LastPush.StartTimeout();
-        buffer.Add(LastPush);
-      }
-    }
+        /// <summary>
+        /// Flag stating whether a channel has been joined once or not.
+        /// </summary>
+        public bool HasJoinedOnce { get; private set; }
 
-    /// <summary>
-    /// Rejoins the channel.
-    /// </summary>
-    /// <param name="timeoutMs"></param>
-    public void Rejoin(int timeoutMs = Constants.DEFAULT_TIMEOUT)
-    {
-      if (IsLeaving) return;
-      SendJoin(timeoutMs);
-    }
+        private Socket socket;
+        private ChannelOptions options;
 
-    private void HandleRejoinTimerElapsed(object sender, ElapsedEventArgs e)
-    {
-      if (isRejoining) return;
-      isRejoining = true;
+        /// <summary>
+        /// The initial request to join a channel (repeated on channel disconnect)
+        /// </summary>
+        internal Push JoinPush;
+        internal Push? LastPush;
 
-      if (State != ChannelState.Closed && State != ChannelState.Errored)
-        return;
+        /// <summary>
+        /// Buffer of Pushes held because of Socket availablity
+        /// </summary>
+        internal List<Push> buffer = new List<Push>();
 
-      Client.Instance.Options.Logger?.Invoke(Topic, "attempting to rejoin", null);
+        private bool canPush => IsJoined;
+        private bool hasJoinedOnce = false;
+        private Timer rejoinTimer;
+        private bool isRejoining = false;
 
-      // Reset join push instance
-      JoinPush = new Push(this, Constants.CHANNEL_EVENT_JOIN, Parameters);
-
-      Rejoin();
-    }
-
-    private void SendJoin(int timeoutMs = Constants.DEFAULT_TIMEOUT)
-    {
-      SetState(ChannelState.Joining);
-
-      // Remove handler if exists
-      JoinPush.OnMessage -= HandleJoinResponse;
-
-      JoinPush.OnMessage += HandleJoinResponse;
-      JoinPush.Resend(timeoutMs);
-    }
-
-    private void HandleJoinResponse(object sender, SocketResponseEventArgs args)
-    {
-      if (args.Response._event == Constants.CHANNEL_EVENT_REPLY)
-      {
-        var obj = JsonConvert.DeserializeObject<PheonixResponse>(JsonConvert.SerializeObject(args.Response.Payload, Client.Instance.SerializerSettings), Client.Instance.SerializerSettings);
-        if (obj.Status == Constants.PHEONIX_STATUS_OK)
+        /// <summary>
+        /// Initializes a Channel - must call `Subscribe()` to receive events.
+        /// </summary>
+        /// <param name="database"></param>
+        /// <param name="schema"></param>
+        /// <param name="table"></param>
+        /// <param name="col"></param>
+        /// <param name="value"></param>
+        public Channel(Socket socket, ChannelOptions options)
         {
-          SetState(ChannelState.Joined);
+            this.options = options;
+            this.socket = socket;
 
-          // Disable Rejoin Timeout
-          rejoinTimer?.Stop();
-          isRejoining = false;
+            if (options.Parameters == null)
+            {
+                options.Parameters = new Dictionary<string, string>();
+            }
+
+            JoinPush = new Push(socket, this, Constants.CHANNEL_EVENT_JOIN, Parameters);
+
+            rejoinTimer = new Timer(options.ClientOptions.Timeout.TotalMilliseconds);
+            rejoinTimer.Elapsed += HandleRejoinTimerElapsed;
+            rejoinTimer.AutoReset = true;
         }
-        else if (obj.Status == Constants.PHEONIX_STATUS_ERROR)
+
+        /// <summary>
+        /// Subscribes to the channel given supplied options/params.
+        /// </summary>
+        /// <param name="timeoutMs"></param>
+        public Task<Channel> Subscribe(int timeoutMs = Constants.DEFAULT_TIMEOUT)
         {
-          SetState(ChannelState.Errored);
+            var tsc = new TaskCompletionSource<Channel>();
 
-          rejoinTimer.Stop();
-          isRejoining = false;
+            if (hasJoinedOnce)
+            {
+                tsc.SetException(new Exception("`Subscribe` can only be called a single time per channel instance."));
+                return tsc.Task;
+            }
+
+            EventHandler<ChannelStateChangedEventArgs>? channelCallback = null;
+            EventHandler? joinPushTimeoutCallback = null;
+
+            channelCallback = (object sender, ChannelStateChangedEventArgs e) =>
+            {
+                switch (e.State)
+                {
+                    // Success!
+                    case ChannelState.Joined:
+                        HasJoinedOnce = true;
+                        StateChanged -= channelCallback;
+                        JoinPush.OnTimeout -= joinPushTimeoutCallback;
+
+                        // Clear buffer
+                        foreach (var item in buffer)
+                            item.Send();
+                        buffer.Clear();
+
+                        tsc.TrySetResult(this);
+                        break;
+                    // Failure
+                    case ChannelState.Closed:
+                    case ChannelState.Errored:
+                        StateChanged -= channelCallback;
+                        JoinPush.OnTimeout -= joinPushTimeoutCallback;
+
+                        tsc.TrySetException(new Exception("Error occurred connecting to channel. Check logs."));
+                        break;
+                }
+            };
+
+            // Throw an exception if there is a problem receiving a join response
+            joinPushTimeoutCallback = (object sender, EventArgs e) =>
+            {
+                StateChanged -= channelCallback;
+                JoinPush.OnTimeout -= joinPushTimeoutCallback;
+
+                tsc.TrySetException(new PushTimeoutException());
+            };
+
+            StateChanged += channelCallback;
+
+            // Set a flag to prevent multiple join attempts.
+            hasJoinedOnce = true;
+
+            // Init and send join.
+            Rejoin(timeoutMs);
+            JoinPush.OnTimeout += joinPushTimeoutCallback;
+
+            return tsc.Task;
         }
-      }
+
+        /// <summary>
+        /// Unsubscribes from the channel.
+        /// </summary>
+        public void Unsubscribe()
+        {
+            SetState(ChannelState.Leaving);
+
+            var leavePush = new Push(socket, this, Constants.CHANNEL_EVENT_LEAVE, null);
+            leavePush.Send();
+
+            TriggerChannelStateEvent(new ChannelStateChangedEventArgs(ChannelState.Closed));
+        }
+
+        /// <summary>
+        /// Sends a `Push` request under this channel.
+        ///
+        /// Maintains a buffer in the event push is called prior to the channel being joined.
+        /// </summary>
+        /// <param name="eventName"></param>
+        /// <param name="payload"></param>
+        /// <param name="timeoutMs"></param>
+        public void Push(string eventName, object payload, int timeoutMs = Constants.DEFAULT_TIMEOUT)
+        {
+            if (!hasJoinedOnce)
+                throw new Exception($"Tried to push '{eventName}' to '{Topic}' before joining. Use `Channel.Subscribe()` before pushing events");
+
+            LastPush = new Push(socket, this, eventName, payload, timeoutMs);
+
+            if (canPush)
+            {
+                LastPush.Send();
+            }
+            else
+            {
+                LastPush.StartTimeout();
+                buffer.Add(LastPush);
+            }
+        }
+
+        /// <summary>
+        /// Rejoins the channel.
+        /// </summary>
+        /// <param name="timeoutMs"></param>
+        public void Rejoin(int timeoutMs = Constants.DEFAULT_TIMEOUT)
+        {
+            if (IsLeaving) return;
+            SendJoin(timeoutMs);
+        }
+
+        private void HandleRejoinTimerElapsed(object sender, ElapsedEventArgs e)
+        {
+            if (isRejoining) return;
+            isRejoining = true;
+
+            if (State != ChannelState.Closed && State != ChannelState.Errored)
+                return;
+
+            options.ClientOptions.Logger?.Invoke(Topic, "attempting to rejoin", null);
+
+            // Reset join push instance
+            JoinPush = new Push(socket, this, Constants.CHANNEL_EVENT_JOIN, Parameters);
+
+            Rejoin();
+        }
+
+        private void SendJoin(int timeoutMs = Constants.DEFAULT_TIMEOUT)
+        {
+            SetState(ChannelState.Joining);
+
+            // Remove handler if exists
+            JoinPush.OnMessage -= HandleJoinResponse;
+
+            JoinPush.OnMessage += HandleJoinResponse;
+            JoinPush.Resend(timeoutMs);
+        }
+
+        private void HandleJoinResponse(object sender, SocketResponseEventArgs args)
+        {
+            if (args.Response._event == Constants.CHANNEL_EVENT_REPLY)
+            {
+                var obj = JsonConvert.DeserializeObject<PheonixResponse>(JsonConvert.SerializeObject(args.Response.Payload, options.SerializerSettings), options.SerializerSettings);
+
+                if (obj == null) return;
+
+                if (obj.Status == Constants.PHEONIX_STATUS_OK)
+                {
+                    SetState(ChannelState.Joined);
+
+                    // Disable Rejoin Timeout
+                    rejoinTimer?.Stop();
+                    isRejoining = false;
+                }
+                else if (obj.Status == Constants.PHEONIX_STATUS_ERROR)
+                {
+                    SetState(ChannelState.Errored);
+
+                    rejoinTimer.Stop();
+                    isRejoining = false;
+                }
+            }
+        }
+
+        private void SetState(ChannelState state)
+        {
+            State = state;
+            StateChanged?.Invoke(this, new ChannelStateChangedEventArgs(state));
+        }
+
+        internal void HandleSocketMessage(SocketResponseEventArgs args)
+        {
+            if (args.Response.Ref == JoinPush.Ref) return;
+
+            // If we don't ignore this event we'll end up with double callbacks.
+            if (args.Response._event == "*") return;
+
+            OnMessage?.Invoke(this, args);
+
+            switch (args.Response.Event)
+            {
+                case Constants.EventType.Insert:
+                    OnInsert?.Invoke(this, args);
+                    break;
+                case Constants.EventType.Update:
+                    OnUpdate?.Invoke(this, args);
+                    break;
+                case Constants.EventType.Delete:
+                    OnDelete?.Invoke(this, args);
+                    break;
+            }
+        }
+
+        private void TriggerChannelStateEvent(ChannelStateChangedEventArgs args, bool shouldRejoin = true)
+        {
+            SetState(args.State);
+
+            if (shouldRejoin)
+            {
+                isRejoining = false;
+                rejoinTimer.Start();
+            }
+            else rejoinTimer.Stop();
+
+            switch (args.State)
+            {
+                case ChannelState.Closed:
+                    OnClose?.Invoke(this, args);
+                    break;
+                case ChannelState.Errored:
+                    OnError?.Invoke(this, args);
+                    break;
+                default:
+                    break;
+            }
+        }
     }
 
-    private void SetState(ChannelState state)
+    public class ChannelStateChangedEventArgs : EventArgs
     {
-      State = state;
-      StateChanged?.Invoke(this, new ChannelStateChangedEventArgs(state));
+        public ChannelState State { get; private set; }
+
+        public ChannelStateChangedEventArgs(ChannelState state)
+        {
+            State = state;
+        }
     }
 
-    internal void HandleSocketMessage(SocketResponseEventArgs args)
+    public class PheonixResponse
     {
-      if (args.Response.Ref == JoinPush.Ref) return;
+        [JsonProperty("response")]
+        public object? Response;
 
-      // If we don't ignore this event we'll end up with double callbacks.
-      if (args.Response._event == "*") return;
-
-      OnMessage?.Invoke(this, args);
-
-      switch (args.Response.Event)
-      {
-        case Constants.EventType.Insert:
-          OnInsert?.Invoke(this, args);
-          break;
-        case Constants.EventType.Update:
-          OnUpdate?.Invoke(this, args);
-          break;
-        case Constants.EventType.Delete:
-          OnDelete?.Invoke(this, args);
-          break;
-      }
+        [JsonProperty("status")]
+        public string? Status;
     }
-
-    private void TriggerChannelStateEvent(ChannelStateChangedEventArgs args, bool shouldRejoin = true)
-    {
-      SetState(args.State);
-
-      if (shouldRejoin)
-      {
-        isRejoining = false;
-        rejoinTimer.Start();
-      }
-      else rejoinTimer.Stop();
-
-      switch (args.State)
-      {
-        case ChannelState.Closed:
-          OnClose?.Invoke(this, args);
-          break;
-        case ChannelState.Errored:
-          OnError?.Invoke(this, args);
-          break;
-        default:
-          break;
-      }
-    }
-  }
-
-  public class ChannelStateChangedEventArgs : EventArgs
-  {
-    public ChannelState State { get; private set; }
-
-    public ChannelStateChangedEventArgs(ChannelState state)
-    {
-      State = state;
-    }
-  }
-
-  public class PheonixResponse
-  {
-    [JsonProperty("response")]
-    public object Response;
-
-    [JsonProperty("status")]
-    public string Status;
-  }
 }

--- a/Realtime/Channel.cs
+++ b/Realtime/Channel.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Timers;
 using Newtonsoft.Json;
 using Supabase.Realtime.Attributes;
+using Supabase.Realtime.Interfaces;
 using static Supabase.Realtime.Channel;
 
 [assembly: InternalsVisibleTo("RealtimeTests")]
@@ -13,7 +14,7 @@ namespace Supabase.Realtime
     /// <summary>
     /// Class representation of a channel subscription
     /// </summary>
-    public class Channel
+    public class Channel : IRealtimeChannel
     {
         /// <summary>
         /// Channel state with associated string representations.
@@ -93,7 +94,7 @@ namespace Supabase.Realtime
         /// </summary>
         public bool HasJoinedOnce { get; private set; }
 
-        private Socket socket;
+        private IRealtimeSocket socket;
 
         /// <summary>
         /// The initial request to join a channel (repeated on channel disconnect)
@@ -119,7 +120,7 @@ namespace Supabase.Realtime
         /// <param name="table"></param>
         /// <param name="col"></param>
         /// <param name="value"></param>
-        public Channel(Socket socket, ChannelOptions options)
+        public Channel(IRealtimeSocket socket, ChannelOptions options)
         {
             this.socket = socket;
 
@@ -138,9 +139,9 @@ namespace Supabase.Realtime
         /// Subscribes to the channel given supplied Options/params.
         /// </summary>
         /// <param name="timeoutMs"></param>
-        public Task<Channel> Subscribe(int timeoutMs = Constants.DEFAULT_TIMEOUT)
+        public Task<IRealtimeChannel> Subscribe(int timeoutMs = Constants.DEFAULT_TIMEOUT)
         {
-            var tsc = new TaskCompletionSource<Channel>();
+            var tsc = new TaskCompletionSource<IRealtimeChannel>();
 
             if (hasJoinedOnce)
             {

--- a/Realtime/ChannelOptions.cs
+++ b/Realtime/ChannelOptions.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Supabase.Realtime
+{
+    public class ChannelOptions
+    {
+        public string Database { get; set; }
+        public string? Schema { get; set; }
+        public string? Table { get; set; }
+
+        public string? Column { get; set; }
+
+        public string? Value { get; set; }
+
+        public Dictionary<string, string>? Parameters { get; set; }
+
+        public ClientOptions ClientOptions { get; set; }
+
+        public JsonSerializerSettings SerializerSettings { get; set; }
+
+        public ChannelOptions(string database, ClientOptions clientOptions, JsonSerializerSettings serializerSettings)
+        {
+            Database = database;
+            ClientOptions = clientOptions;
+            SerializerSettings = serializerSettings;
+        }
+    }
+}

--- a/Realtime/Client.cs
+++ b/Realtime/Client.cs
@@ -41,7 +41,7 @@ namespace Supabase.Realtime
         private Socket? socket;
 
         /// <summary>
-        /// Client Options - most of which are regarding Socket connection options
+        /// Client Options - most of which are regarding Socket connection Options
         /// </summary>
         public ClientOptions Options { get; private set; }
 
@@ -272,7 +272,7 @@ namespace Supabase.Realtime
                 foreach (var channel in subscriptions.Values)
                 {
                     // See: https://github.com/supabase/realtime-js/pull/126
-                    channel.Parameters["user_token"] = accessToken;
+                    channel.Options.Parameters!["user_token"] = accessToken;
 
                     if (channel.HasJoinedOnce && channel.IsJoined)
                     {

--- a/Realtime/Client.cs
+++ b/Realtime/Client.cs
@@ -37,47 +37,33 @@ namespace Supabase.Realtime
         ///
         /// Most methods of the Client act as proxies to the Socket class.
         /// </summary>
-        public Socket Socket { get; private set; }
+        public Socket? Socket { get => socket; }
+        private Socket? socket;
 
         /// <summary>
         /// Client Options - most of which are regarding Socket connection options
         /// </summary>
         public ClientOptions Options { get; private set; }
 
-        private static Client instance;
-        /// <summary>
-        /// The Client Instance (singleton)
-        /// </summary>
-        public static Client Instance
-        {
-            get
-            {
-                if (instance == null)
-                    instance = new Client();
-
-                return instance;
-            }
-        }
-
         /// <summary>
         /// Invoked when the socket raises the `open` event.
         /// </summary>
-        public event EventHandler<SocketStateChangedEventArgs> OnOpen;
+        public event EventHandler<SocketStateChangedEventArgs>? OnOpen;
 
         /// <summary>
         /// Invoked when the socket raises the `close` event.
         /// </summary>
-        public event EventHandler<SocketStateChangedEventArgs> OnClose;
+        public event EventHandler<SocketStateChangedEventArgs>? OnClose;
 
         /// <summary>
         /// Invoked when the socket raises the `error` event.
         /// </summary>
-        public event EventHandler<SocketStateChangedEventArgs> OnError;
+        public event EventHandler<SocketStateChangedEventArgs>? OnError;
 
         /// <summary>
         /// Invoked when the socket raises the `message` event.
         /// </summary>
-        public event EventHandler<SocketStateChangedEventArgs> OnMessage;
+        public event EventHandler<SocketStateChangedEventArgs>? OnMessage;
 
         /// <summary>
         /// Custom Serializer resolvers and converters that will be used for encoding and decoding Postgrest JSON responses.
@@ -103,7 +89,8 @@ namespace Supabase.Realtime
                             DateTimeStyles = Options.DateTimeStyles,
                             DateTimeFormat = Options.DateTimeFormat
                         }
-                    }
+                    },
+                    MissingMemberHandling = MissingMemberHandling.Ignore
                 };
             }
         }
@@ -113,7 +100,8 @@ namespace Supabase.Realtime
         /// <summary>
         /// JWT Access token for WALRUS security
         /// </summary>
-        internal string AccessToken { get; private set; }
+        internal string? AccessToken { get => accessToken; }
+        private string? accessToken;
 
         /// <summary>
         /// Initializes a Client instance, this method should be called prior to any other method.
@@ -121,21 +109,28 @@ namespace Supabase.Realtime
         /// <param name="realtimeUrl">The connection url (ex: "ws://localhost:4000/socket" - no trailing slash required)</param>
         /// <param name="options"></param>
         /// <returns>Client</returns>
-        public static Client Initialize(string realtimeUrl, ClientOptions options = null)
+        public Client(string realtimeUrl, ClientOptions? options = null)
         {
+            this.realtimeUrl = realtimeUrl;
+            
             if (options == null)
-            {
                 options = new ClientOptions();
+
+            if (options.Encode == null)
+                options.Encode = (payload, callback) => callback(JsonConvert.SerializeObject(payload, SerializerSettings));
+
+            if (options.Decode == null)
+            {
+                options.Decode = (payload, callback) =>
+                {
+                    var response = new SocketResponse(SerializerSettings);
+                    JsonConvert.PopulateObject(payload, response, SerializerSettings);
+                    callback(response);
+                };
             }
 
-            instance = new Client
-            {
-                Options = options,
-                realtimeUrl = realtimeUrl,
-                subscriptions = new Dictionary<string, Channel>()
-            };
-
-            return instance;
+            Options = options;
+            subscriptions = new Dictionary<string, Channel>();
         }
 
         /// <summary>
@@ -150,39 +145,37 @@ namespace Supabase.Realtime
 
             try
             {
-                if (Socket != null)
+                if (socket != null)
                 {
                     Debug.WriteLine("Socket already exists.");
-
                     tsc.TrySetResult(this);
-
                     return tsc.Task;
                 }
 
-                EventHandler<SocketStateChangedEventArgs> callback = null;
+                EventHandler<SocketStateChangedEventArgs>? callback = null;
                 callback = (object sender, SocketStateChangedEventArgs args) =>
                 {
                     switch (args.State)
                     {
                         case SocketStateChangedEventArgs.ConnectionState.Open:
-                            Socket.StateChanged -= callback;
+                            Socket!.StateChanged -= callback;
                             tsc.TrySetResult(this);
                             break;
                         case SocketStateChangedEventArgs.ConnectionState.Close:
                         case SocketStateChangedEventArgs.ConnectionState.Error:
-                            Socket.StateChanged -= callback;
+                            Socket!.StateChanged -= callback;
                             tsc.TrySetException(new Exception("Error occurred connecting to Socket. Check logs."));
                             break;
                     }
                 };
 
-                Socket = new Socket(realtimeUrl, Options);
+                socket = new Socket(realtimeUrl, Options, SerializerSettings);
 
-                Socket.StateChanged += HandleSocketStateChanged;
-                Socket.OnMessage += HandleSocketMessage;
+                socket.StateChanged += HandleSocketStateChanged;
+                socket.OnMessage += HandleSocketMessage;
 
-                Socket.StateChanged += callback;
-                Socket.Connect();
+                socket.StateChanged += callback;
+                socket.Connect();
             }
             catch (Exception ex)
             {
@@ -199,39 +192,52 @@ namespace Supabase.Realtime
         /// </summary>
         /// <param name="callback"></param>
         /// <returns></returns>
-        public Client Connect(Action<Client> callback = null)
+        public Client Connect(Action<Client>? callback = null)
         {
-            if (Socket != null)
+            if (socket != null)
             {
                 Debug.WriteLine("Socket already exists.");
                 return this;
             }
 
-            EventHandler<SocketStateChangedEventArgs> cb = null;
+            EventHandler<SocketStateChangedEventArgs>? cb = null;
+
             cb = (object sender, SocketStateChangedEventArgs args) =>
             {
                 switch (args.State)
                 {
                     case SocketStateChangedEventArgs.ConnectionState.Open:
-                        Socket.StateChanged -= cb;
+                        socket!.StateChanged -= cb;
                         callback?.Invoke(this);
                         break;
                     case SocketStateChangedEventArgs.ConnectionState.Close:
                     case SocketStateChangedEventArgs.ConnectionState.Error:
-                        Socket.StateChanged -= cb;
+                        socket!.StateChanged -= cb;
                         throw new Exception("Error occurred connecting to Socket. Check logs.");
                 }
             };
 
-            Socket = new Socket(realtimeUrl, Options);
+            socket = new Socket(realtimeUrl, Options, SerializerSettings);
 
-            Socket.StateChanged += HandleSocketStateChanged;
-            Socket.OnMessage += HandleSocketMessage;
+            socket.StateChanged += HandleSocketStateChanged;
+            socket.OnMessage += HandleSocketMessage;
+            socket.OnHeartbeat += HandleSocketHeartbeat;
 
-            Socket.StateChanged += cb;
-            Socket.Connect();
+            socket.StateChanged += cb;
+            socket.Connect();
 
             return this;
+        }
+
+        /// <summary>
+        /// Sets the current Access Token every heartbeat (see: https://github.com/supabase/realtime-js/blob/59bd47956ebe4e23b3e1a6c07f5fe2cfe943e8ad/src/RealtimeClient.ts#L437)
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void HandleSocketHeartbeat(object sender, SocketResponseEventArgs e)
+        {
+            if (!string.IsNullOrEmpty(accessToken))
+                SetAuth(accessToken!);
         }
 
         /// <summary>
@@ -242,12 +248,12 @@ namespace Supabase.Realtime
         /// <returns></returns>
         public Client Disconnect(WebSocketCloseStatus code = WebSocketCloseStatus.NormalClosure, string reason = "Programmatic Disconnect")
         {
-            if (Socket != null)
+            if (socket != null)
             {
-                Socket.StateChanged -= HandleSocketStateChanged;
-                Socket.OnMessage -= HandleSocketMessage;
-                Socket.Disconnect(code, reason);
-                Socket = null;
+                socket.StateChanged -= HandleSocketStateChanged;
+                socket.OnMessage -= HandleSocketMessage;
+                socket.Disconnect(code, reason);
+                socket = null;
             }
             return this;
         }
@@ -259,20 +265,20 @@ namespace Supabase.Realtime
         /// <param name="jwt"></param>
         public void SetAuth(string jwt)
         {
-            AccessToken = jwt;
+            accessToken = jwt;
 
             try
             {
                 foreach (var channel in subscriptions.Values)
                 {
                     // See: https://github.com/supabase/realtime-js/pull/126
-                    channel.Parameters["user_token"] = AccessToken;
+                    channel.Parameters["user_token"] = accessToken;
 
                     if (channel.HasJoinedOnce && channel.IsJoined)
                     {
                         channel.Push(Constants.CHANNEL_ACCESS_TOKEN, new Dictionary<string, string>
                         {
-                            { "access_token", AccessToken }
+                            { "access_token", accessToken }
                         });
                     }
                 }
@@ -292,7 +298,7 @@ namespace Supabase.Realtime
         /// <param name="column">Postgres column name</param>
         /// <param name="value">Value the specified column should have</param>
         /// <returns></returns>
-        public Channel Channel(string database = "realtime", string schema = null, string table = null, string column = null, string value = null, Dictionary<string, string> parameters = null)
+        public Channel Channel(string database = "realtime", string? schema = null, string? table = null, string? column = null, string? value = null, Dictionary<string, string>? parameters = null)
         {
             var key = Utils.GenerateChannelTopic(database, schema, table, column, value);
 
@@ -301,7 +307,18 @@ namespace Supabase.Realtime
                 return subscriptions[key];
             }
 
-            var subscription = new Channel(database, schema, table, column, value, parameters);
+            if (socket == null) throw new Exception("Socket must exist, was Connect called?");
+
+            var channelOptions = new ChannelOptions(database, Options, SerializerSettings)
+            {
+                Schema = schema,
+                Table = table,
+                Column = column,
+                Value = value,
+                Parameters = parameters
+            };
+
+            var subscription = new Channel(socket!, channelOptions);
             subscriptions.Add(key, subscription);
 
             return subscription;
@@ -324,7 +341,7 @@ namespace Supabase.Realtime
 
         private void HandleSocketMessage(object sender, SocketResponseEventArgs args)
         {
-            if (subscriptions.ContainsKey(args.Response.Topic))
+            if (args.Response.Topic != null && subscriptions.ContainsKey(args.Response.Topic))
             {
                 subscriptions[args.Response.Topic].HandleSocketMessage(args);
             }
@@ -337,7 +354,10 @@ namespace Supabase.Realtime
             {
                 case SocketStateChangedEventArgs.ConnectionState.Open:
                     // Ref: https://github.com/supabase/realtime-js/pull/116/files
-                    SetAuth(AccessToken);
+                    if (!string.IsNullOrEmpty(AccessToken))
+                    {
+                        SetAuth(AccessToken!);
+                    }
 
                     OnOpen?.Invoke(this, args);
                     break;

--- a/Realtime/Client.cs
+++ b/Realtime/Client.cs
@@ -6,6 +6,7 @@ using System.Net.WebSockets;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Supabase.Realtime.Interfaces;
 
 namespace Supabase.Realtime
 {
@@ -17,7 +18,7 @@ namespace Supabase.Realtime
     /// <example>
     ///     client = Client.Instance
     /// </example>
-    public class Client
+    public class Client : IRealtimeClient<Socket, Channel>
     {
         /// <summary>
         /// Contains all Realtime Channel Subscriptions - state managed internally.
@@ -37,8 +38,8 @@ namespace Supabase.Realtime
         ///
         /// Most methods of the Client act as proxies to the Socket class.
         /// </summary>
-        public Socket? Socket { get => socket; }
-        private Socket? socket;
+        public IRealtimeSocket? Socket { get => socket; }
+        private IRealtimeSocket? socket;
 
         /// <summary>
         /// Client Options - most of which are regarding Socket connection Options
@@ -112,7 +113,7 @@ namespace Supabase.Realtime
         public Client(string realtimeUrl, ClientOptions? options = null)
         {
             this.realtimeUrl = realtimeUrl;
-            
+
             if (options == null)
                 options = new ClientOptions();
 
@@ -139,9 +140,9 @@ namespace Supabase.Realtime
         /// Returns when socket has successfully connected.
         /// </summary>
         /// <returns></returns>
-        public Task<Client> ConnectAsync()
+        public Task<IRealtimeClient<Socket, Channel>> ConnectAsync()
         {
-            var tsc = new TaskCompletionSource<Client>();
+            var tsc = new TaskCompletionSource<IRealtimeClient<Socket, Channel>>();
 
             try
             {
@@ -192,7 +193,7 @@ namespace Supabase.Realtime
         /// </summary>
         /// <param name="callback"></param>
         /// <returns></returns>
-        public Client Connect(Action<Client>? callback = null)
+        public IRealtimeClient<Socket, Channel> Connect(Action<IRealtimeClient<Socket, Channel>>? callback = null)
         {
             if (socket != null)
             {
@@ -246,7 +247,7 @@ namespace Supabase.Realtime
         /// <param name="code">Status Code</param>
         /// <param name="reason">Reason for disconnect</param>
         /// <returns></returns>
-        public Client Disconnect(WebSocketCloseStatus code = WebSocketCloseStatus.NormalClosure, string reason = "Programmatic Disconnect")
+        public IRealtimeClient<Socket, Channel> Disconnect(WebSocketCloseStatus code = WebSocketCloseStatus.NormalClosure, string reason = "Programmatic Disconnect")
         {
             if (socket != null)
             {

--- a/Realtime/ClientOptions.cs
+++ b/Realtime/ClientOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Supabase.Realtime
 {
@@ -11,17 +12,17 @@ namespace Supabase.Realtime
         /// <summary>
         /// The function to encode outgoing messages. Defaults to JSON
         /// </summary>
-        public Action<object, Action<string>> Encode { get; set; } = (payload, callback) => callback(JsonConvert.SerializeObject(payload,Client.Instance.SerializerSettings));
+        public Action<object, Action<string>>? Encode { get; set; }
 
         /// <summary>
         /// The function to decode incoming messages.
         /// </summary>
-        public Action<string, Action<SocketResponse>> Decode { get; set; } = (payload, callback) => callback(JsonConvert.DeserializeObject<SocketResponse>(payload, Client.Instance.SerializerSettings));
+        public Action<string, Action<SocketResponse?>>? Decode { get; set; }
 
         /// <summary>
         /// Logging function
         /// </summary>
-        public Action<string, string, object> Logger { get; set; } = (kind, msg, data) => Debug.WriteLine($"{kind}: {msg}, {JsonConvert.SerializeObject(data, Formatting.Indented)}");
+        public Action<string, string, object?> Logger { get; set; } = (kind, msg, data) => Debug.WriteLine($"{kind}: {msg}, {JsonConvert.SerializeObject(data, Formatting.Indented)}");
 
         /// <summary>
         /// The Websocket Transport, for example WebSocket.

--- a/Realtime/Converters/DateTimeConverter.cs
+++ b/Realtime/Converters/DateTimeConverter.cs
@@ -15,11 +15,7 @@ namespace Supabase.Realtime.Converters
 
         public override bool CanWrite => false;
 
-        public override object ReadJson(
-            JsonReader reader,
-            Type objectType,
-            object existingValue,
-            JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             if (reader.Value != null)
             {
@@ -76,7 +72,7 @@ namespace Supabase.Realtime.Converters
             return null;
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/Realtime/Converters/IntArrayConverter.cs
+++ b/Realtime/Converters/IntArrayConverter.cs
@@ -15,13 +15,13 @@ namespace Supabase.Realtime.Converters
 
         public override bool CanConvert(Type objectType) => throw new NotImplementedException();
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             try
             {
                 if (reader.Value != null)
                 {
-                    return Parse(reader.Value as string);
+                    return Parse((string)reader.Value);
                 }
                 else
                 {
@@ -36,7 +36,7 @@ namespace Supabase.Realtime.Converters
             }
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/Realtime/Converters/StringArrayConverter.cs
+++ b/Realtime/Converters/StringArrayConverter.cs
@@ -15,13 +15,13 @@ namespace Supabase.Realtime.Converters
 
         public override bool CanConvert(Type objectType) => throw new NotImplementedException();
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             try
             {
                 if (reader.Value != null)
                 {
-                    return Parse(reader.Value as string);
+                    return Parse((string)reader.Value);
                 }
                 else
                 {
@@ -36,7 +36,7 @@ namespace Supabase.Realtime.Converters
             }
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             throw new NotImplementedException();
         }

--- a/Realtime/Interfaces/IRealtimeChannel.cs
+++ b/Realtime/Interfaces/IRealtimeChannel.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Supabase.Realtime.Interfaces
+{
+    public interface IRealtimeChannel
+    {
+        bool HasJoinedOnce { get; }
+        bool IsClosed { get; }
+        bool IsErrored { get; }
+        bool IsJoined { get; }
+        bool IsJoining { get; }
+        bool IsLeaving { get; }
+        ChannelOptions Options { get; }
+        Channel.ChannelState State { get; }
+        string Topic { get; }
+
+        event EventHandler<ChannelStateChangedEventArgs> OnClose;
+        event EventHandler<SocketResponseEventArgs> OnDelete;
+        event EventHandler<ChannelStateChangedEventArgs> OnError;
+        event EventHandler<SocketResponseEventArgs> OnInsert;
+        event EventHandler<SocketResponseEventArgs> OnMessage;
+        event EventHandler<SocketResponseEventArgs> OnUpdate;
+        event EventHandler<ChannelStateChangedEventArgs> StateChanged;
+
+        void Push(string eventName, object payload, int timeoutMs = 10000);
+        void Rejoin(int timeoutMs = 10000);
+        Task<IRealtimeChannel> Subscribe(int timeoutMs = 10000);
+        void Unsubscribe();
+    }
+}

--- a/Realtime/Interfaces/IRealtimeClient.cs
+++ b/Realtime/Interfaces/IRealtimeClient.cs
@@ -1,0 +1,31 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Net.WebSockets;
+using System.Threading.Tasks;
+
+namespace Supabase.Realtime.Interfaces
+{
+    public interface IRealtimeClient<TSocket, TChannel>
+        where TSocket: IRealtimeSocket
+        where TChannel: IRealtimeChannel
+    {
+        ClientOptions Options { get; }
+        JsonSerializerSettings SerializerSettings { get; }
+        IRealtimeSocket? Socket { get; }
+        ReadOnlyDictionary<string, TChannel> Subscriptions { get; }
+
+        event EventHandler<SocketStateChangedEventArgs> OnClose;
+        event EventHandler<SocketStateChangedEventArgs> OnError;
+        event EventHandler<SocketStateChangedEventArgs> OnMessage;
+        event EventHandler<SocketStateChangedEventArgs> OnOpen;
+
+        Channel Channel(string database = "realtime", string? schema = null, string? table = null, string? column = null, string? value = null, Dictionary<string, string>? parameters = null);
+        IRealtimeClient<TSocket, TChannel> Connect(Action<IRealtimeClient<TSocket, TChannel>>? callback = null);
+        Task<IRealtimeClient<TSocket, TChannel>> ConnectAsync();
+        IRealtimeClient<TSocket, TChannel> Disconnect(WebSocketCloseStatus code = WebSocketCloseStatus.NormalClosure, string reason = "Programmatic Disconnect");
+        void Remove(TChannel channel);
+        void SetAuth(string jwt);
+    }
+}

--- a/Realtime/Interfaces/IRealtimePush.cs
+++ b/Realtime/Interfaces/IRealtimePush.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Supabase.Realtime.Interfaces
+{
+    public interface IRealtimePush<TChannel, TSocketResponse>
+        where TChannel : IRealtimeChannel
+        where TSocketResponse: IRealtimeSocketResponse
+    {
+        TChannel Channel { get; }
+        string EventName { get; }
+        bool IsSent { get; }
+        SocketRequest? Message { get; }
+        object? Payload { get; }
+        string? Ref { get; }
+        IRealtimeSocketResponse? Response { get; }
+
+        event EventHandler<SocketResponseEventArgs>? OnMessage;
+        event EventHandler? OnTimeout;
+
+        void Resend(int timeoutMs = 10000);
+        void Send();
+    }
+}

--- a/Realtime/Interfaces/IRealtimeSocket.cs
+++ b/Realtime/Interfaces/IRealtimeSocket.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Net.WebSockets;
+
+namespace Supabase.Realtime.Interfaces
+{
+    public interface IRealtimeSocket
+    {
+        bool IsConnected { get; }
+
+        event EventHandler<SocketResponseEventArgs> OnHeartbeat;
+        event EventHandler<SocketResponseEventArgs> OnMessage;
+        event EventHandler<SocketStateChangedEventArgs> StateChanged;
+
+        void Connect();
+        void Disconnect(WebSocketCloseStatus code = WebSocketCloseStatus.NormalClosure, string reason = "");
+        string MakeMsgRef();
+        void Push(SocketRequest data);
+        string ReplyEventName(string msgRef);
+    }
+}

--- a/Realtime/Interfaces/IRealtimeSocketResponse.cs
+++ b/Realtime/Interfaces/IRealtimeSocketResponse.cs
@@ -1,0 +1,16 @@
+﻿using Postgrest.Models;
+
+namespace Supabase.Realtime.Interfaces
+{
+    public interface IRealtimeSocketResponse
+    {
+        string? _event { get; set; }
+        Constants.EventType Event { get; }
+        SocketResponsePayload? Payload { get; set; }
+        string? Ref { get; set; }
+        string? Topic { get; set; }
+
+        T? Model<T>() where T : BaseModel, new();
+        T? OldModel<T>() where T : BaseModel, new();
+    }
+}

--- a/Realtime/Push.cs
+++ b/Realtime/Push.cs
@@ -19,13 +19,13 @@ namespace Supabase.Realtime
         /// <summary>
         /// Invoked when the server has responded to a request.
         /// </summary>
-        public event EventHandler<SocketResponseEventArgs> OnMessage;
+        public event EventHandler<SocketResponseEventArgs>? OnMessage;
 
         /// <summary>
         /// Invoked when this `Push` has not been responded to within the timeout interval.
         /// </summary>
-        public event EventHandler OnTimeout;
-        public SocketResponse Response { get; private set; }
+        public event EventHandler? OnTimeout;
+        public SocketResponse? Response { get; private set; }
 
         /// <summary>
         /// The associated channel.
@@ -40,22 +40,24 @@ namespace Supabase.Realtime
         /// <summary>
         /// Payload of data to be sent.
         /// </summary>
-        public object Payload { get; private set; }
+        public object? Payload { get; private set; }
 
         /// <summary>
         /// Represents the Pushed (sent) Message
         /// </summary>
-        public SocketRequest Message { get; private set; }
+        public SocketRequest? Message { get; private set; }
 
         /// <summary>
         /// Ref Of this Message
         /// </summary>
-        public string Ref { get; private set; }
+        public string? Ref { get; private set; }
 
         private int timeoutMs;
         private Timer timer;
 
-        private string msgRefEvent;
+        private string? msgRefEvent;
+
+        private Socket socket;
 
         /// <summary>
         /// Initilizes a single request that will be `Pushed` to the Socket server.
@@ -64,8 +66,10 @@ namespace Supabase.Realtime
         /// <param name="eventName"></param>
         /// <param name="payload"></param>
         /// <param name="timeoutMs"></param>
-        public Push(Channel channel, string eventName, object payload, int timeoutMs = Constants.DEFAULT_TIMEOUT)
+        public Push(Socket socket, Channel channel, string eventName, object? payload, int timeoutMs = Constants.DEFAULT_TIMEOUT)
         {
+            this.socket = socket;
+
             Channel = channel;
             EventName = eventName;
             Payload = payload;
@@ -75,7 +79,7 @@ namespace Supabase.Realtime
             timer = new Timer(this.timeoutMs);
             timer.Elapsed += TimeoutReached;
 
-            Channel.Socket.OnMessage += HandleSocketMessage;
+            socket.OnMessage += HandleSocketMessage;
         }
 
         /// <summary>
@@ -106,7 +110,7 @@ namespace Supabase.Realtime
                 Payload = Payload,
                 Ref = Ref
             };
-            Channel.Socket.Push(Message);
+            socket.Push(Message);
         }
 
         /// <summary>
@@ -116,8 +120,8 @@ namespace Supabase.Realtime
         {
             timer.Stop();
             timer.Start();
-            Ref = Client.Instance.Socket.MakeMsgRef();
-            msgRefEvent = Client.Instance.Socket.ReplyEventName(Ref);
+            Ref = socket.MakeMsgRef();
+            msgRefEvent = socket.ReplyEventName(Ref);
         }
 
         /// <summary>
@@ -132,7 +136,7 @@ namespace Supabase.Realtime
                 CancelTimeout();
                 Response = args.Response;
                 OnMessage?.Invoke(this, args);
-                Channel.Socket.OnMessage -= HandleSocketMessage;
+                socket.OnMessage -= HandleSocketMessage;
             }
         }
 

--- a/Realtime/Push.cs
+++ b/Realtime/Push.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Supabase.Realtime.Interfaces;
+using System;
 using System.Timers;
 
 namespace Supabase.Realtime
@@ -9,7 +10,7 @@ namespace Supabase.Realtime
     /// `Push` also adds additional functionality for retrying, timeouts, and listeners
     /// for its associated response from the server.
     /// </summary>
-    public class Push
+    public class Push : IRealtimePush<Channel, SocketResponse>
     {
         /// <summary>
         /// Flag representing the `sent` state of a request.
@@ -25,7 +26,7 @@ namespace Supabase.Realtime
         /// Invoked when this `Push` has not been responded to within the timeout interval.
         /// </summary>
         public event EventHandler? OnTimeout;
-        public SocketResponse? Response { get; private set; }
+        public IRealtimeSocketResponse? Response { get; private set; }
 
         /// <summary>
         /// The associated channel.
@@ -52,12 +53,11 @@ namespace Supabase.Realtime
         /// </summary>
         public string? Ref { get; private set; }
 
+        private string? msgRefEvent;
         private int timeoutMs;
         private Timer timer;
 
-        private string? msgRefEvent;
-
-        private Socket socket;
+        private IRealtimeSocket socket;
 
         /// <summary>
         /// Initilizes a single request that will be `Pushed` to the Socket server.
@@ -66,7 +66,7 @@ namespace Supabase.Realtime
         /// <param name="eventName"></param>
         /// <param name="payload"></param>
         /// <param name="timeoutMs"></param>
-        public Push(Socket socket, Channel channel, string eventName, object? payload, int timeoutMs = Constants.DEFAULT_TIMEOUT)
+        public Push(IRealtimeSocket socket, Channel channel, string eventName, object? payload, int timeoutMs = Constants.DEFAULT_TIMEOUT)
         {
             this.socket = socket;
 

--- a/Realtime/Realtime.csproj
+++ b/Realtime/Realtime.csproj
@@ -19,6 +19,11 @@
 		<PackageVersion>3.0.1</PackageVersion>
 		<ReleaseVersion>3.0.1</ReleaseVersion>
 	</PropertyGroup>
+	<PropertyGroup>
+		<Nullable>enable</Nullable>
+		<LangVersion>8.0</LangVersion>
+		<WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
+	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Version)' == '' ">
 		<VersionPrefix Condition=" '$(VersionPrefix)' == '' ">3.0.1</VersionPrefix>
 		<VersionSuffix Condition=" '$(VersionSuffix)' == '' ">
@@ -27,7 +32,7 @@
 		<Version Condition=" '$(Version)' == '' ">$(VersionPrefix)</Version>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="postgrest-csharp" Version="2.0.8" />
+		<PackageReference Include="postgrest-csharp" Version="2.1.1" />
 		<PackageReference Include="Websocket.Client" Version="4.4.43" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>

--- a/Realtime/SocketResponse.cs
+++ b/Realtime/SocketResponse.cs
@@ -1,0 +1,113 @@
+﻿using Newtonsoft.Json;
+using Postgrest.Models;
+using Supabase.Realtime.Interfaces;
+using static Supabase.Realtime.Constants;
+
+namespace Supabase.Realtime
+{
+    /// <summary>
+    /// Representation of a Socket Response.
+    /// </summary>
+    public class SocketResponse : IRealtimeSocketResponse
+    {
+        private JsonSerializerSettings serializerSettings;
+        public SocketResponse(JsonSerializerSettings serializerSettings)
+        {
+            this.serializerSettings = serializerSettings;
+        }
+
+        /// <summary>
+        /// Hydrates the referenced record into a Model (if possible).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public T? Model<T>() where T : BaseModel, new()
+        {
+            if (Json != null && Payload != null && Payload.Record != null)
+            {
+                var response = JsonConvert.DeserializeObject<SocketResponse<T>>(Json, serializerSettings);
+                return response?.Payload?.Record;
+            }
+            else
+            {
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Hydrates the old_record into a Model (if possible).
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public T? OldModel<T>() where T : BaseModel, new()
+        {
+            if (Json != null && Payload != null && Payload.OldRecord != null)
+            {
+                var response = JsonConvert.DeserializeObject<SocketResponse<T>>(Json, serializerSettings);
+                return response?.Payload?.OldRecord;
+            }
+            else
+            {
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// The internal realtime topic.
+        /// </summary>
+        [JsonProperty("topic")]
+        public string? Topic { get; set; }
+
+        [JsonProperty("event")]
+        public string? _event { get; set; }
+
+        [JsonIgnore]
+        public EventType Event
+        {
+            get
+            {
+                if (Payload == null) return EventType.Unknown;
+
+                switch (Payload.Type)
+                {
+                    case "INSERT":
+                        return EventType.Insert;
+                    case "UPDATE":
+                        return EventType.Update;
+                    case "DELETE":
+                        return EventType.Delete;
+                }
+
+                return EventType.Unknown;
+            }
+        }
+
+        /// <summary>
+        /// The payload/response.
+        /// </summary>
+        [JsonProperty("payload")]
+        public SocketResponsePayload? Payload { get; set; }
+
+        /// <summary>
+        /// An internal reference to this particular feedback loop.
+        /// </summary>
+        [JsonProperty("ref")]
+        public string? Ref { get; set; }
+
+        [JsonIgnore]
+        internal string? Json { get; set; }
+    }
+
+    /// <summary>
+    /// A SocketResponse with support for Generically typed Payload
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public class SocketResponse<T> : SocketResponse where T : BaseModel, new()
+    {
+        public SocketResponse(JsonSerializerSettings serializerSettings) : base(serializerSettings)
+        { }
+
+        [JsonProperty("payload")]
+        public new SocketResponsePayload<T>? Payload { get; set; }
+    }
+}

--- a/Realtime/Utils.cs
+++ b/Realtime/Utils.cs
@@ -12,7 +12,7 @@ namespace Supabase.Realtime
         /// </summary>
         /// <param name="dict"></param>
         /// <returns></returns>
-        public static string QueryString(IDictionary<string, string> dict)
+        public static string QueryString(IDictionary<string, string?> dict)
         {
             var list = new List<string>();
             foreach (var item in dict)
@@ -32,10 +32,10 @@ namespace Supabase.Realtime
         /// <param name="col"></param>
         /// <param name="value"></param>
         /// <returns></returns>
-        public static string GenerateChannelTopic(string database, string schema, string table, string col, string value)
+        public static string GenerateChannelTopic(string database, string? schema, string? table, string? col, string? value)
         {
-            var list = new List<String> { database, schema, table };
-            string channel = String.Join(":", list.Where(s => !string.IsNullOrEmpty(s)));
+            var list = new List<string?> { database, schema, table };
+            string channel = string.Join(":", list.Where(s => !string.IsNullOrEmpty(s)));
 
             if (!string.IsNullOrEmpty(col) && !string.IsNullOrEmpty(value))
             {

--- a/RealtimeExample/Program.cs
+++ b/RealtimeExample/Program.cs
@@ -12,7 +12,7 @@ namespace RealtimeExample
         {
             // Connect to db and web socket server
             var postgrestClient = Postgrest.Client.Initialize("http://localhost:3000");
-            var realtimeClient = Supabase.Realtime.Client.Initialize("ws://localhost:4000/socket");
+            var realtimeClient = new Client("ws://localhost:4000/socket");
 
             //Socket events
             realtimeClient.OnOpen += (s, args) => Console.WriteLine("OPEN");

--- a/RealtimeTests/API.cs
+++ b/RealtimeTests/API.cs
@@ -16,14 +16,14 @@ namespace RealtimeTests
         private string socketEndpoint = "ws://localhost:4000/socket";
         private string restEndpoint = "http://localhost:3000";
 
-        private Client SocketClient;
         private Postgrest.Client RestClient => Postgrest.Client.Initialize(restEndpoint);
+        private Client SocketClient;
 
 
         [TestInitialize]
         public async Task InitializeTest()
         {
-            SocketClient = Client.Initialize(socketEndpoint);
+            SocketClient = new Client(socketEndpoint);
             await SocketClient.ConnectAsync();
         }
 
@@ -166,7 +166,7 @@ namespace RealtimeTests
         {
             var subscription1 = SocketClient.Channel("realtime", "public", "todos");
             var subscription2 = SocketClient.Channel("realtime", "public", "todos");
-            var subscription3 = SocketClient.Channel("realtime", "public", "todos", "user_id", "1"); 
+            var subscription3 = SocketClient.Channel("realtime", "public", "todos", "user_id", "1");
 
             Assert.AreEqual(subscription1.Topic, subscription2.Topic);
 
@@ -257,7 +257,7 @@ namespace RealtimeTests
         {
             var tsc = new TaskCompletionSource<bool>();
 
-            var channel = SocketClient.Channel("realtime", "public", "todos");
+            var channel = SocketClient.Channel("realtime", "*");
 
             channel.OnInsert += (object sender, SocketResponseEventArgs e) =>
             {
@@ -315,8 +315,8 @@ namespace RealtimeTests
             var token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.C8oVtF5DICct_4HcdSKt8pdrxBFMQOAnPpbiiUbaXAY";
 
             // No subscriptions should show a push
-            Client.Instance.SetAuth(token);
-            foreach (var subscription in Client.Instance.Subscriptions.Values)
+            SocketClient.SetAuth(token);
+            foreach (var subscription in SocketClient.Subscriptions.Values)
             {
                 Assert.IsNull(subscription.LastPush);
             }
@@ -324,8 +324,8 @@ namespace RealtimeTests
             await channel.Subscribe();
             await channel2.Subscribe();
 
-            Client.Instance.SetAuth(token);
-            foreach (var subscription in Client.Instance.Subscriptions.Values)
+            SocketClient.SetAuth(token);
+            foreach (var subscription in SocketClient.Subscriptions.Values)
             {
                 Assert.IsTrue(subscription.LastPush.EventName == Constants.CHANNEL_ACCESS_TOKEN);
             }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - db
 
   realtime:
-    image: supabase/realtime:latest
+    image: supabase/realtime:v0.25.1
     restart: unless-stopped
     ports:
       - "4000:4000"
@@ -32,7 +32,7 @@ services:
       - db
 
   db:
-    image: supabase/postgres:14.1.0.77
+    image: postgres:15
     restart: unless-stopped
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - db
 
   db:
-    image: postgres:latest
+    image: supabase/postgres:14.1.0.77
     restart: unless-stopped
     ports:
       - "5432:5432"


### PR DESCRIPTION
This pull represents a restructuring of the entire project to support Dependency Injection and Nullability (ref: supabase-community/supabase-csharp#34 and #16). Unfortunately this introduces some breaking API changes.

- `Client` is no longer a singleton class.
- `Channel` has a new constructor that uses `ChannelOptions`
- `Channel.Parameters` has been changed in favor of `Channel.Options`
- `Channel` and `Push` are now directly dependent on having `Socket` and `SerializerSettings` passed in as opposed to referencing the `Singleton` instance.
- All publicly facing classes (that offer functionality) now include an Interface.

In reality, not much should affect the developer as most of these classes/methods are only being referenced internally by the `Client`. The removal of the Singleton aspect may offer some design changes for those leveraging this library by itself (as opposed to using it only in supabase-csharp.)

```c#
// What was:
var client = Supabase.Realtime.Client.Initialize(options);
await client.ConnectAsync()

// Becomes:
var client = new Client(options);
await client.ConnectAsync()
```