### PR TITLE
Client.cs patch - Fixes Connect() not returning callback result when the socket isn't null

### DIFF
--- a/Realtime/Client.cs
+++ b/Realtime/Client.cs
@@ -179,6 +179,7 @@ namespace Supabase.Realtime
 			if (socket != null)
 			{
 				Options.Logger("error", "Socket already exists.", null);
+				callback?.Invoke(this);
 				return this;
 			}
 


### PR DESCRIPTION
Fixes Connect() not returning callback result when the socket isn't null.

## What kind of change does this PR introduce?

Added `callback?.Invoke(this);` to Connect() in Client.cs

## What is the current behavior?

ConnectAync() hangs when Connect() doesn't return a callback result.

Which is also used by [supabase-csharp](https://github.com/supabase-community/supabase-csharp) - `client.InitializeAsync();`

https://github.com/supabase-community/supabase-csharp/issues/60

## What is the new behavior?
Connect() invokes the callback and then returns.
ConnectAync() Doesn't get stuck when the socket isn't null.

## Additional context

This issue was introduced in 5.0.2, I believe before the result was created using `TrySetResult()` istead of `SetResult` Callback.
