### PR TITLE
Upgrades Websocket.Client to 5.1.0 & target framework to Standard 2.1

### DIFF
--- a/Realtime/Realtime.csproj
+++ b/Realtime/Realtime.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <PackageId>realtime-csharp</PackageId>
         <Authors>Joseph Schultz &lt;joseph@acupofjose.com&gt;</Authors>
         <Description>Realtime-csharp is written as a client library for supabase/realtime.</Description>
@@ -40,7 +40,7 @@
     <ItemGroup>
         <PackageReference Include="postgrest-csharp" Version="3.4.0" />
         <PackageReference Include="supabase-core" Version="0.0.3" />
-        <PackageReference Include="Websocket.Client" Version="4.6.1" />
+        <PackageReference Include="Websocket.Client" Version="5.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 

--- a/Realtime/RealtimeSocket.cs
+++ b/Realtime/RealtimeSocket.cs
@@ -9,7 +9,6 @@ using Supabase.Realtime.Socket;
 using Supabase.Realtime.Exceptions;
 using Supabase.Realtime.Interfaces;
 using Websocket.Client;
-using Websocket.Client.Models;
 using static Supabase.Realtime.Constants;
 
 namespace Supabase.Realtime;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the WebSocket dependency library

## Additional context

The new version has a memory usage improvement that I want to benefit from.

As part of the new version it also increased its target to .netstandard 2.1, so I followed suit here. Should that entail a new major version, is that a breaking change?
