### PR TITLE
chore: grant DML on public tables to API roles in test schema migration

### DIFF
--- a/supabase/migrations/20250224164421_init.sql
+++ b/supabase/migrations/20250224164421_init.sql
@@ -183,3 +183,15 @@ from users
 WHERE username = name_param;
 $$
     LANGUAGE SQL IMMUTABLE;
+
+-- Tables created by the `postgres` role in the `public` schema no longer inherit
+-- SELECT/INSERT/UPDATE/DELETE for the API roles under current Supabase CLI default privileges
+-- (https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically),
+-- so the privileges must be granted explicitly.
+grant select, insert, update, delete on all tables in schema public to anon, authenticated, service_role;
+grant usage, select on all sequences in schema public to anon, authenticated, service_role;
+grant execute on all functions in schema public to anon, authenticated, service_role;
+
+alter default privileges in schema public grant select, insert, update, delete on tables to anon, authenticated, service_role;
+alter default privileges in schema public grant usage, select on sequences to anon, authenticated, service_role;
+alter default privileges in schema public grant execute on functions to anon, authenticated, service_role;


### PR DESCRIPTION
## Problem

Against a current `supabase start` stack, 20 of 30 tests fail — the direct failures are `permission denied for table todos` (42501), and the rest are downstream (subscriptions waiting on inserts that never happened).

Root cause: since Supabase's May 30, 2026 breaking change ([changelog 45329](https://supabase.com/changelog/45329-breaking-change-tables-not-exposed-to-data-and-graphql-api-automatically)), tables created by the `postgres` role in the `public` schema no longer inherit SELECT/INSERT/UPDATE/DELETE for `anon`/`authenticated`/`service_role` — API exposure is now opt-in. The init migration creates its tables without any explicit grants, so the API roles end up with no DML at all (`has_table_privilege('anon','public.todos','insert')` → `false`). CI hasn't surfaced this because it uses unpinned `supabase-cli@latest` and hasn't run since before the change.

## Fix

Grant the privileges explicitly in the init migration:

- `select, insert, update, delete` on all `public` tables to the API roles,
- `usage, select` on sequences (identity columns on insert),
- `execute` on functions,
- matching `alter default privileges` so tables added by future migrations stay covered.

Same fix as supabase-community/supabase-csharp#268 and supabase-community/postgrest-csharp#121 — not a monorepo, so it must be applied per repo.

## Verification

- Before: `TZ=UTC dotnet test` → **20 failed / 10 passed**, `anon` insert on `public.todos` = false.
- After `supabase db reset` (grants sourced only from the migration): `TZ=UTC dotnet test` → **30/30 pass**, `anon` insert = true.