### PR TITLE
feat: add OnPostgresChange for one-call postgres_changes listeners

### DIFF
--- a/Realtime/Interfaces/IRealtimeChannel.cs
+++ b/Realtime/Interfaces/IRealtimeChannel.cs
@@ -132,6 +132,32 @@ public interface IRealtimeChannel
     void ClearMessageReceivedHandlers();
 
     /// <summary>
+    /// Registers a postgres_changes listener and its handler in a single call, then returns the channel
+    /// so registrations can be chained before <see cref="Subscribe"/>. This is the idiomatic replacement
+    /// for pairing <see cref="Register(PostgresChangesOptions)"/> with
+    /// <see cref="AddPostgresChangeHandler"/>.
+    /// </summary>
+    /// <param name="postgresChangeHandler">The handler invoked when a matching change is received.</param>
+    /// <param name="listenType">The change type to listen for.</param>
+    /// <param name="filter">
+    /// Optional targeting — schema, table, and row filter. When omitted, listens to every table in the
+    /// <c>public</c> schema.
+    /// </param>
+    /// <returns>The same channel, to allow chaining further registrations.</returns>
+    /// <example>
+    /// <code>
+    /// await client.Channel("public:todos")
+    ///     .OnPostgresChange(
+    ///         (_, change) => Console.WriteLine(change.Model&lt;Todo&gt;()),
+    ///         ListenType.Inserts,
+    ///         new PostgresChangesFilter { Table = "todos" })
+    ///     .Subscribe();
+    /// </code>
+    /// </example>
+    IRealtimeChannel OnPostgresChange(PostgresChangesHandler postgresChangeHandler, ListenType listenType,
+        PostgresChangesFilter? filter = null);
+
+    /// <summary>
     /// Add a postgres_changes handler
     /// </summary>
     /// <param name="listenType"></param>

--- a/Realtime/PostgresChanges/PostgresChangesFilter.cs
+++ b/Realtime/PostgresChanges/PostgresChangesFilter.cs
@@ -1,0 +1,29 @@
+namespace Supabase.Realtime.PostgresChanges;
+
+/// <summary>
+/// Optional targeting for an <c>OnPostgresChange</c> listener — which schema, table, and rows to
+/// listen to. The event to listen for is passed separately as a <see cref="PostgresChangesOptions.ListenType"/>
+/// parameter; this object carries only the remaining, optional criteria (all with safe defaults).
+/// </summary>
+/// <example>
+/// <code>
+/// new PostgresChangesFilter { Table = "todos", Filter = "id=eq.1" }
+/// </code>
+/// </example>
+public class PostgresChangesFilter
+{
+    /// <summary>
+    /// The Postgres schema to listen to. Defaults to <c>public</c>.
+    /// </summary>
+    public string Schema { get; set; } = "public";
+
+    /// <summary>
+    /// The table to listen to. <c>null</c> (the default) listens to every table in the schema.
+    /// </summary>
+    public string? Table { get; set; }
+
+    /// <summary>
+    /// An optional row filter in PostgREST syntax, e.g. <c>id=eq.1</c>.
+    /// </summary>
+    public string? Filter { get; set; }
+}

--- a/Realtime/RealtimeChannel.cs
+++ b/Realtime/RealtimeChannel.cs
@@ -337,6 +337,16 @@ public class RealtimeChannel : IRealtimeChannel
             handler.Invoke(this, message);
     }
 
+    /// <inheritdoc />
+    public IRealtimeChannel OnPostgresChange(PostgresChangesHandler postgresChangeHandler, ListenType listenType,
+        PostgresChangesFilter? filter = null)
+    {
+        filter ??= new PostgresChangesFilter();
+        RegisterPostgresChangesOptions(new PostgresChangesOptions(filter.Schema, filter.Table, listenType, filter.Filter));
+        BindPostgresChangesHandler(listenType, postgresChangeHandler);
+        return this;
+    }
+
     /// <summary>
     /// Add a postgres changes listener. Should be paired with <see cref="Register"/>.
     /// </summary>
@@ -429,10 +439,19 @@ public class RealtimeChannel : IRealtimeChannel
     /// <returns></returns>
     public IRealtimeChannel Register(PostgresChangesOptions postgresChangesOptions)
     {
-        PostgresChangesOptions.Add(postgresChangesOptions);
-        
-        BindPostgresChangesOptions(postgresChangesOptions);
+        RegisterPostgresChangesOptions(postgresChangesOptions);
         return this;
+    }
+
+    /// <summary>
+    /// Records postgres_changes options for this channel and binds them, so both <see cref="Register"/>
+    /// and <see cref="OnPostgresChange"/> share a single registration path.
+    /// </summary>
+    /// <param name="postgresChangesOptions"></param>
+    private void RegisterPostgresChangesOptions(PostgresChangesOptions postgresChangesOptions)
+    {
+        PostgresChangesOptions.Add(postgresChangesOptions);
+        BindPostgresChangesOptions(postgresChangesOptions);
     }
 
     /// <summary>

--- a/RealtimeTests/ChannelPostgresChangesTests.cs
+++ b/RealtimeTests/ChannelPostgresChangesTests.cs
@@ -342,5 +342,28 @@ public class ChannelPostgresChangesTests
        Assert.IsTrue(insertTask2.Task.Result);
        Assert.IsTrue(insertTask3.Task.Result);
     }
-    
+
+    [TestMethod]
+    public async Task OnPostgresChange_ShouldRegisterAndDeliverToHandler_GivenChainedSubscribe()
+    {
+        var tsc = new TaskCompletionSource<bool>();
+
+        await _socketClient!.Channel("public:todos")
+            .OnPostgresChange((_, changes) => tsc.TrySetResult(changes.Model<Todo>() != null),
+                ListenType.Inserts, new PostgresChangesFilter { Table = "todos" })
+            .Subscribe();
+
+        await _restClient!.Table<Todo>()
+            .Insert(new Todo { UserId = 1, Details = "OnPostgresChange receives insert? ✅" });
+
+        Assert.IsTrue(await WithinTimeout(tsc.Task),
+            "OnPostgresChange should register the option and bind the handler in one call, and return the channel so Subscribe can be chained");
+    }
+
+    private static async Task<bool> WithinTimeout(Task<bool> task, int timeoutMs = 15000)
+    {
+        var completed = await Task.WhenAny(task, Task.Delay(timeoutMs));
+        return completed == task && task.Result;
+    }
+
 }


### PR DESCRIPTION
## What

Adds `IRealtimeChannel.OnPostgresChange(...)` — a single, chainable call that
registers a `postgres_changes` listener and binds its handler, returning the
channel so listeners compose before `Subscribe()`.

```csharp
await client.Channel("public:todos")
    .OnPostgresChange(OnInsert, ListenType.Inserts, new() { Table = "todos" })
    .Subscribe();
```

Signature:
```
IRealtimeChannel OnPostgresChange(
    PostgresChangesHandler handler,
    ListenType listenType,
    PostgresChangesFilter? filter = null);
```

## Why

A postgres_changes listener currently requires two paired calls —
Register(new PostgresChangesOptions(...)) followed by
AddPostgresChangeHandler(...) — which is easy to get wrong and doesn't read
as a single intent. OnPostgresChange collapses that into one call and mirrors
the reference channel.on('postgres_changes', { event, schema, table, filter }, cb)
from realtime-js, expressed idiomatically.

## Design notes

- ListenType is a first-class parameter, always — never embedded in an
options object in one form and top-level in another. Only the optional
targeting (schema/table/row-filter) lives in PostgresChangesFilter, passed
as a single defaulted argument.
- New PostgresChangesFilter rather than reusing PostgresChangesOptions.
The latter is a shipped, wire-facing type whose event is settable only via
its constructor; making it object-initializer-friendly would break released
API. The new input type maps to it internally, keeping this change additive.
- Additive only — no existing signature, default, or serialized shape
changes.

## Relationship to #54

First of three focused PRs carved out of the stale draft #54. Much of that
draft is now superseded by master: the Supabase CLI test-infra migration,
postgres filter support (#55), and private channels (#61) already landed, so
this PR ports only the OnPostgresChange idea, rebased and brought to standard.

## Testing

- New E2E acceptance test exercises registration + delivery + chaining through
the public surface against a local supabase start stack.
- Full realtime test suite green (42/42).
- Clean build, zero new analyzer/nullable/doc warnings.

Follow-ups (out of scope here)

- Deprecating the two-step Register + AddPostgresChangeHandler in favour
of OnPostgresChange — deferred to a follow-up after the channel-naming PR so
callers can migrate cleanly.
- Known limitation: multiple postgres_changes bindings on one channel only
route correctly when the first registered option is event *. This is a
pre-existing bug in the binding-id routing (it affects the two-step API too),
tracked separately.