### PR TITLE
fix: guard Channel against double 'realtime:' prefix

### DIFF
--- a/Realtime/Client.cs
+++ b/Realtime/Client.cs
@@ -340,7 +340,11 @@ public class Client : IRealtimeClient<RealtimeSocket, RealtimeChannel>
     /// <summary>
     /// Adds a RealtimeChannel subscription - if a subscription exists with the same signature, the existing subscription will be returned.
     /// </summary>
-    /// <param name="channelName">The name of the Channel to join (totally arbitrary)</param>
+    /// <param name="channelName">
+    /// The name of the Channel to join (totally arbitrary). The topic is namespaced under a
+    /// <c>realtime:</c> prefix; a name that already begins with <c>realtime:</c> is used as-is
+    /// rather than prefixed again.
+    /// </param>
     /// <returns></returns>
     /// <exception cref="Exception"></exception>
     public RealtimeChannel Channel(string channelName) =>
@@ -349,13 +353,18 @@ public class Client : IRealtimeClient<RealtimeSocket, RealtimeChannel>
     /// <summary>
     /// Adds a RealtimeChannel subscription with custom options - if a subscription exists with the same signature, the existing subscription will be returned.
     /// </summary>
-    /// <param name="channelName">The name of the Channel to join</param>
+    /// <param name="channelName">
+    /// The name of the Channel to join. The topic is namespaced under a <c>realtime:</c> prefix; a name
+    /// that already begins with <c>realtime:</c> is used as-is rather than prefixed again.
+    /// </param>
     /// <param name="options">Custom channel options for configuring the subscription</param>
     /// <returns>A RealtimeChannel instance representing the subscription</returns>
     /// <exception cref="Exception">Thrown when Socket is null, indicating Connect() was not called</exception>
     public RealtimeChannel Channel(string channelName, ChannelOptions options)
     {
-        var topic = $"realtime:{channelName}";
+        var topic = channelName.StartsWith("realtime:", StringComparison.Ordinal)
+            ? channelName
+            : $"realtime:{channelName}";
 
         if (_subscriptions.TryGetValue(topic, out var channel))
             return channel;

--- a/RealtimeTests/ClientTests.cs
+++ b/RealtimeTests/ClientTests.cs
@@ -81,6 +81,14 @@ public class ClientTests
         Assert.AreEqual(true, channel2.IsJoined);
     }
 
+    [TestMethod]
+    public void Channel_ShouldNotDoublePrefixTopic_GivenNameAlreadyPrefixed()
+    {
+        var prefixed = client!.Channel("realtime:public:todos");
+        Assert.AreEqual("realtime:public:todos", prefixed.Topic);
+        Assert.AreSame(prefixed, client!.Channel("public:todos"));
+    }
+
     [TestMethod("Client: Removes Channel Subscriptions")]
     public async Task ClientCanRemoveChannelSubscription()
     {


### PR DESCRIPTION
## What

`Channel(name)` namespaces its topic under a `realtime:` prefix. When the
supplied name already began with `realtime:`, it was prefixed a second time —
producing an unusable `realtime:realtime:...` topic. This guards against that:
a name already starting with `realtime:` is used as-is.

```csharp
client.Channel("public:todos").Topic;           // "realtime:public:todos"
client.Channel("realtime:public:todos").Topic;  // "realtime:public:todos"  (was: realtime:realtime:public:todos)
```

## Why

Callers who already hold a fully-qualified topic — copied from another client,
logged output, or the {database}:{schema}:{table} form produced by the
multi-param overload — got silently broken channels. Prefixing is now
idempotent.

## Details

- The guard sits in Channel(string, ChannelOptions), the single place that
literally prepends realtime:. Channel(string) delegates to it, so both
overloads are covered.
- Normalization runs before the subscription-cache lookup, so a prefixed
and unprefixed name for the same logical topic now resolve to the same
cached channel instead of two separate subscriptions.
- The multi-param Channel(database, schema, table, …) overload builds its
topic from parts via GenerateChannelTopic and has no double-prefix path, so
it is untouched.

## Behavior change

For anyone currently passing a realtime:-prefixed name to Channel(string),
the produced topic changes from realtime:realtime:… to realtime:…. The
previous form was the broken case, so this is a fix — but it is a topic-string
change and is called out here for reviewers.

## Relationship to #54

Second of three focused PRs carved out of the stale draft #54, rebased onto
current master and brought to standard. #54 applied the same guard to only
one overload; this places it at the shared prepend site so both are covered.

## Testing

- Channel_ShouldNotDoublePrefixTopic_GivenNameAlreadyPrefixed asserts the
normalized topic and the single-instance dedupe through the public surface.
Verified it catches the regression: with the guard reverted it fails with
actual: "realtime:realtime:public:todos".
- Full realtime suite green (43/43). Clean build, zero new warnings.