### PR TITLE
fix: omit null table from postgres_changes join payload

### DIFF
--- a/Realtime/PostgresChanges/PostgresChangesOptions.cs
+++ b/Realtime/PostgresChanges/PostgresChangesOptions.cs
@@ -57,9 +57,11 @@ public class PostgresChangesOptions
     public string Schema { get; set; }
 
     /// <summary>
-    /// The table for this listener, can be: `*` matching all tables in schema.
+    /// The table for this listener, can be: `*` matching all tables in schema. When <c>null</c>
+    /// (a schema-wide listener), the <c>table</c> key is omitted from the join payload rather than
+    /// sent as <c>null</c>.
     /// </summary>
-    [JsonProperty("table")]
+    [JsonProperty("table", NullValueHandling = NullValueHandling.Ignore)]
     public string? Table { get; set; }
 
     /// <summary>

--- a/RealtimeTests/Serialization/PostgresChangesOptionsTests.cs
+++ b/RealtimeTests/Serialization/PostgresChangesOptionsTests.cs
@@ -1,0 +1,29 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Supabase.Realtime.PostgresChanges;
+
+namespace RealtimeTests;
+
+/// <summary>
+/// Wire-shape of <see cref="PostgresChangesOptions"/> as it is serialized into a channel's
+/// join <c>config.postgres_changes</c> payload.
+/// </summary>
+[TestClass]
+public class PostgresChangesOptionsTests
+{
+    [TestMethod]
+    public void Table_ShouldBeOmittedFromJson_WhenNull()
+    {
+        // A schema-wide listener has no table; the server expects the key absent, not `"table": null`.
+        var json = JsonConvert.SerializeObject(new PostgresChangesOptions("public"));
+        Assert.IsFalse(JObject.Parse(json).ContainsKey("table"));
+    }
+
+    [TestMethod]
+    public void Table_ShouldBeSerialized_WhenProvided()
+    {
+        var json = JsonConvert.SerializeObject(new PostgresChangesOptions("public", "todos"));
+        Assert.AreEqual("todos", JObject.Parse(json)["table"]?.Value<string>());
+    }
+}


### PR DESCRIPTION
## What

A schema-wide `postgres_changes` listener has no table, so `Table` is `null`.
That was serialized into the join `config.postgres_changes` payload as
`"table": null`, whereas the server expects the key to be **absent**. Adding
`NullValueHandling.Ignore` drops the key when `Table` is null.

```jsonc
// before — schema-wide listener
{ "event": "*", "schema": "public", "table": null }
// after
{ "event": "*", "schema": "public" }
```

## Why

Sending "table": null is not the shape the realtime server expects for a
schema-wide subscription; omitting the key matches the reference realtime-js
config object, where an absent table means "every table in the schema."

## Wire-shape change

This changes the serialized join payload for schema-wide listeners only
("table": null → key omitted). Listeners that specify a table are unaffected.
Called out here for reviewers; the package has no payload snapshot suite, so
there is nothing to re-approve.

## Relationship to #54

Third of three focused PRs carved out of the stale draft #54, rebased onto
current master and brought to standard. #54 bundled this attribute change
with an unrelated [Obsolete] on PostgresChangesOptions.Parameters; that
deprecation is intentionally left out of this PR and deferred to the follow-up
that retires the two-step postgres_changes API.

## Testing

- PostgresChangesOptionsTests (hermetic serialization): table is omitted
when null, and serialized when provided. Verified the null case catches the
regression — pre-fix it fails with the table key present.
- Full realtime suite green (45/45). Clean build, zero new warnings.